### PR TITLE
Icon directory creation fails on Ubuntu due to AppArmor restriction

### DIFF
--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -836,7 +836,8 @@ if [[ -d "$RELAY_DIR" ]]; then
 
     if [[ -n "$_relay_user" ]]; then
         ICON_DEST="${_relay_home}/.local/share/icons/hicolor/symbolic/apps"
-        sudo -u "$_relay_user" mkdir -p "$ICON_DEST"
+        sudo mkdir -p "$ICON_DEST"
+        sudo chown -R "$_relay_user":"$_relay_user" "${_relay_home}/.local/share/icons"
         for icon in camera-disabled-symbolic camera-switch-symbolic camera-video-symbolic; do
             if [[ -f "$RELAY_DIR/yaru-icons/${icon}.svg" ]]; then
                 sudo -u "$_relay_user" cp "$RELAY_DIR/yaru-icons/${icon}.svg" "$ICON_DEST/"

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1187,7 +1187,8 @@ if [[ -d "$RELAY_DIR" ]]; then
 
     if [[ -n "$_relay_user" ]]; then
         ICON_DEST="${_relay_home}/.local/share/icons/hicolor/symbolic/apps"
-        sudo -u "$_relay_user" mkdir -p "$ICON_DEST"
+        sudo mkdir -p "$ICON_DEST"
+        sudo chown -R "$_relay_user":"$_relay_user" "${_relay_home}/.local/share/icons"
         for icon in camera-disabled-symbolic camera-switch-symbolic camera-video-symbolic; do
             if [[ -f "$RELAY_DIR/yaru-icons/${icon}.svg" ]]; then
                 sudo -u "$_relay_user" cp "$RELAY_DIR/yaru-icons/${icon}.svg" "$ICON_DEST/"


### PR DESCRIPTION
# Fix: Icon directory creation fails on Ubuntu due to AppArmor restriction

## Problem

On Ubuntu 26.04, the icon directory creation in step 13 fails with `Permission Denied`:

```
mkdir: Permission denied
  ✗ Webcam Fix (Book 5) exited with code 1
```

The failing line is:
```bash
sudo -u "$_relay_user" mkdir -p "$ICON_DEST"
```

Ubuntu's AppArmor policy blocks `sudo -u <user> mkdir` for paths under `/home` when
invoked from within a root (pkexec) context, even when the target user and path are
valid. This is a known Ubuntu 26.04 AppArmor restriction.

## Fix

Replace the `sudo -u` mkdir call with a plain `sudo mkdir` followed by a `chown` to
correct ownership:

```bash
# Before
sudo -u "$_relay_user" mkdir -p "$ICON_DEST"

# After
sudo mkdir -p "$ICON_DEST"
sudo chown -R "$_relay_user":"$_relay_user" "${_relay_home}/.local/share/icons"
```

The `chown` is applied from `icons` downward since `.local/share` already exists
on a clean Ubuntu install and we only want to fix ownership of directories we created.

## Testing

- Confirmed fix resolves the `Permission Denied` error on Ubuntu 26.04 (kernel 7.0,
  GNOME, AppArmor enabled)
- Confirmed no regression on Fedora 44 (KDE Plasma, SELinux)
