### PR TITLE
Ubuntu 26.04 Compatibility Fixes

### DIFF
--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -259,6 +259,8 @@ detect_ipa_path() {
     local path
     for path in /usr/local/lib/x86_64-linux-gnu/libcamera \
                 /usr/local/lib/aarch64-linux-gnu/libcamera \
+                /usr/lib/x86_64-linux-gnu/libcamera \
+                /usr/lib/aarch64-linux-gnu/libcamera \
                 /usr/lib64/libcamera /usr/lib/libcamera /usr/local/lib/libcamera \
                 /lib64/libcamera /lib/libcamera; do
         if find "$path" -name "*.so" -path "*/ipa/*" 2>/dev/null | grep -q .; then

--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -572,6 +572,8 @@ elif [[ "$DISTRO" == "ubuntu" ]]; then
         IPA_PATH="/usr/local/lib/libcamera/ipa"
     elif [[ -d "/usr/local/lib/x86_64-linux-gnu/libcamera/ipa" ]]; then
         IPA_PATH="/usr/local/lib/x86_64-linux-gnu/libcamera/ipa"
+    elif [[ -d "/usr/lib/x86_64-linux-gnu/libcamera/ipa" ]]; then
+        IPA_PATH="/usr/lib/x86_64-linux-gnu/libcamera/ipa"
     else
         IPA_PATH="/usr/lib/libcamera/ipa"
     fi
@@ -586,7 +588,7 @@ fi
 # to /usr/local which PipeWire's systemd service doesn't search by default.
 SPA_PATH=""
 if [[ "$DISTRO" == "ubuntu" ]]; then
-    SPA_PLUGIN=$(find /usr/local/lib -path "*/spa-*/libcamera/libspa-libcamera.so" 2>/dev/null | head -1)
+    SPA_PLUGIN=$(find /usr/local/lib /usr/lib -path "*/spa-*/libcamera/libspa-libcamera.so" 2>/dev/null | head -1)
     if [[ -n "$SPA_PLUGIN" ]]; then
         # Extract the spa-0.2 directory (parent of libcamera/)
         SPA_PATH=$(dirname "$(dirname "$SPA_PLUGIN")")
@@ -856,6 +858,19 @@ if [[ -d "$RELAY_DIR" ]]; then
     fi
 else
     echo "  ⚠ camera-relay directory not found — skipping relay tool installation"
+fi
+
+# Ubuntu: ensure the user is in the video group so WirePlumber can access
+# /dev/media0. This must be done after _relay_user is set so we have a
+# reliable username regardless of whether the script is run as root.
+if [[ -n "$_relay_user" ]]; then
+    if ! groups "$_relay_user" | grep -q "\bvideo\b"; then
+        echo "  Adding $_relay_user to video group (required for /dev/media0 access)..."
+        sudo usermod -aG video "$_relay_user"
+        echo "  ⚠ $_relay_user must log out and back in for the video group to take effect."
+    else
+        echo "  ✓ $_relay_user already in video group"
+    fi
 fi
 
 # ──────────────────────────────────────────────

--- a/webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh
+++ b/webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh
@@ -868,6 +868,12 @@ elif [[ "$DISTRO" == "arch" ]]; then
     # so this is safe.
     USE_FULL_INSTALL=true
     info "Full install: Arch Linux (so-only install breaks IPA path resolution)."
+elif [[ "$DISTRO" == "debian" || "$DISTRO" == "ubuntu" ]]; then
+    # Ubuntu/Debian: IPA modules must match the patched library's build hash.
+    # The .so-only approach preserves distro IPA .sign files which were built
+    # against the original library — causing signature mismatch and camera failure.
+    USE_FULL_INSTALL=true
+    info "Full install: Ubuntu/Debian (IPA modules must match patched library)."
 fi
 
 if [[ "$USE_FULL_INSTALL" == "true" ]]; then
@@ -930,10 +936,10 @@ else
     # not match the distro's layout.
     if [[ -n "${LIBCAMERA_IPA_DIR:-}" && -d "$LIBCAMERA_IPA_DIR" ]]; then
         IPA_ENV_FILE="/etc/profile.d/libcamera-ipa-path.sh"
-        echo "export LIBCAMERA_IPA_MODULE_PATH=$LIBCAMERA_IPA_DIR" > "$IPA_ENV_FILE"
+        echo "export LIBCAMERA_IPA_MODULE_PATH=$LIBCAMERA_IPA_DIR/ipa" > "$IPA_ENV_FILE"
         chmod 644 "$IPA_ENV_FILE"
-        export LIBCAMERA_IPA_MODULE_PATH="$LIBCAMERA_IPA_DIR"
-        ok "IPA module path configured: $LIBCAMERA_IPA_DIR"
+        export LIBCAMERA_IPA_MODULE_PATH="$LIBCAMERA_IPA_DIR/ipa"
+        ok "IPA module path configured: $LIBCAMERA_IPA_DIR/ipa"
         info "  Environment file: $IPA_ENV_FILE"
     fi
 


### PR DESCRIPTION
# PR: Ubuntu 26.04 Compatibility Fixes

Fixes Issue ([#35](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/35#issue-4232727641))
## Summary

This PR fixes three issues that prevent the webcam fix from working on Ubuntu 26.04 (Resolute Raccoon) with repo-installed libcamera 0.7.0. The scripts were originally written and tested against Ubuntu 25.10 where libcamera had to be compiled from source into `/usr/local/`. On Ubuntu 26.04, libcamera 0.7.0 is available from the standard repos and installs to the standard Ubuntu multiarch path `/usr/lib/x86_64-linux-gnu/`.

## Test Environment

- **Hardware:** Samsung Galaxy Book 5 Pro (940XHA), Intel Lunar Lake
- **OS:** Ubuntu 26.04 (Resolute Raccoon), kernel 7.0.0-12-generic
- **libcamera:** 0.7.0-1ubuntu2 (repo-installed)

---

## Changes

### 1. `webcam-fix-book5/install.sh` — IPA path detection

**Problem:** The Ubuntu IPA path detection block was missing `/usr/lib/x86_64-linux-gnu/libcamera/ipa` — the path where Ubuntu 26.04's repo-installed libcamera puts its IPA modules. Without this entry, the path fell through to the incorrect `/usr/lib/libcamera/ipa` fallback, causing libcamera to fail to find its IPA modules.

```diff
     elif [[ -d "/usr/local/lib/x86_64-linux-gnu/libcamera/ipa" ]]; then
         IPA_PATH="/usr/local/lib/x86_64-linux-gnu/libcamera/ipa"
+    elif [[ -d "/usr/lib/x86_64-linux-gnu/libcamera/ipa" ]]; then
+        IPA_PATH="/usr/lib/x86_64-linux-gnu/libcamera/ipa"
     else
         IPA_PATH="/usr/lib/libcamera/ipa"
     fi
```

### 2. `webcam-fix-book5/install.sh` — SPA plugin detection

**Problem:** The PipeWire SPA plugin search only looked in `/usr/local/lib`, missing the repo-installed plugin at `/usr/lib/x86_64-linux-gnu/spa-0.2/libcamera/libspa-libcamera.so`.

```diff
-    SPA_PLUGIN=$(find /usr/local/lib -path "*/spa-*/libcamera/libspa-libcamera.so" 2>/dev/null | head -1)
+    SPA_PLUGIN=$(find /usr/local/lib /usr/lib -path "*/spa-*/libcamera/libspa-libcamera.so" 2>/dev/null | head -1)
```

---

### 3. `webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh` — Full install for Ubuntu/Debian

**Problem:** The bayer fix script has two install modes — a full install (`ninja install`) which replaces the library and IPA modules together with matching signatures, and a so-only install which replaces only the `.so` files while preserving the distro's IPA `.sign` files.

On Ubuntu 26.04 the so-only install causes a signature mismatch. The patched library has a different build hash from the original, so the distro `.sign` files are rejected and libcamera falls back to `/usr/src/ipa`:

```
INFO IPAManager: libcamera is not installed. Adding '/usr/src/ipa' to the IPA search path
```

This results in no camera being detected despite the library being installed correctly. The fix is to use the full install path for Ubuntu/Debian, the same as already done for Arch Linux:

```diff
 elif [[ "$DISTRO" == "arch" ]]; then
     USE_FULL_INSTALL=true
     info "Full install: Arch Linux (so-only install breaks IPA path resolution)."
+elif [[ "$DISTRO" == "debian" || "$DISTRO" == "ubuntu" ]]; then
+    # Ubuntu/Debian: IPA modules must match the patched library's build hash.
+    # The .so-only approach preserves distro IPA .sign files which were built
+    # against the original library — causing signature mismatch and camera failure.
+    USE_FULL_INSTALL=true
+    info "Full install: Ubuntu/Debian (IPA modules must match patched library)."
 fi
```

---

### 4. `camera-relay` — IPA path detection

**Problem:** The `detect_ipa_path()` function was missing the `/usr/lib/` Ubuntu multiarch paths for both x86_64 and aarch64. These are added after the `/usr/local/`
entries so source builds still take priority over repo-installed libcamera.

```diff
     for path in /usr/local/lib/x86_64-linux-gnu/libcamera \
                 /usr/local/lib/aarch64-linux-gnu/libcamera \
+                /usr/lib/x86_64-linux-gnu/libcamera \
+                /usr/lib/aarch64-linux-gnu/libcamera \
                 /usr/lib64/libcamera /usr/lib/libcamera /usr/local/lib/libcamera \
                 /lib64/libcamera /lib/libcamera; do
```



### 5. `video` group check (all distros)

WirePlumber needs access to `/dev/media0` to expose the camera to PipeWire.
This device is owned by group `video` and the user must be a member or the
camera will not appear in any apps despite the kernel modules loading correctly.
This applies to all distros — some desktop installers add the user to `video`
automatically but it is not guaranteed.

The check is placed after the camera-relay installation block where
`_relay_user` is already set — this gives a reliable username regardless of
whether the script is run as root or as the logged-in user. Adding a user to
`video` when they are already a member is harmless.

```bash
if [[ -n "$_relay_user" ]]; then
    if ! groups "$_relay_user" | grep -q "\bvideo\b"; then
        echo "  Adding $_relay_user to video group..."
        sudo usermod -aG video "$_relay_user"
        echo "  ⚠ $_relay_user must log out and back in for the video group to take effect."
    else
        echo "  ✓ $_relay_user already in video group"
    fi
fi
```

---
