### PR TITLE
Fix kernel version check and add missing distro detection entries

### DIFF
--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -160,7 +160,7 @@ KVER=$(uname -r)
 KMAJOR=$(echo "$KVER" | cut -d. -f1)
 KMINOR=$(echo "$KVER" | cut -d. -f2)
 
-if [[ "$KMAJOR" -lt 6 ]] || { [[ "$KMAJOR" -eq 6 ]] && [[ "$KMINOR" -lt 18 ]]; }; then
+if [[ "$KMAJOR" -lt 6 ]] || { [[ "$KMAJOR" -eq 6 ]] && [[ "$KMINOR" -lt 17 ]]; }; then
     echo "ERROR: Kernel ${KVER} is too old. IPU7 webcam support requires kernel 6.18+."
     echo ""
     echo "       Kernel 6.18 includes in-tree IPU7, USBIO, and OV02C10 drivers."

--- a/webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh
+++ b/webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh
@@ -137,7 +137,7 @@ detect_distro() {
     if [[ -f /etc/os-release ]]; then
         . /etc/os-release
         case "$ID" in
-            ubuntu|debian|linuxmint|pop)
+            ubuntu|debian|linuxmint|pop|zorin)
                 DISTRO="debian"
                 DISTRO_NAME="$PRETTY_NAME"
                 ;;
@@ -145,7 +145,7 @@ detect_distro() {
                 DISTRO="fedora"
                 DISTRO_NAME="$PRETTY_NAME"
                 ;;
-            arch|manjaro|endeavouros)
+            arch|manjaro|endeavouros|cachyos)
                 DISTRO="arch"
                 DISTRO_NAME="$PRETTY_NAME"
                 ;;


### PR DESCRIPTION
# PR: Fix kernel version check and add missing distro detection entries

@Andycodeman

## Summary

Two small fixes to support additional Linux distributions, motivated by ongoing
multi-distro testing of a companion script (`webcam-full.sh`) that automates
package installation and source builds of libcamera/PipeWire across distros that
don't ship a usable libcamera version.

>The `webcam-full.sh` script isn't included here as I have a lot of testing to do on 8 different Linux distros that I have installed on my Book 5 Pro.  With possibly more distros to test.

Regardless of the `webcam-full.sh` , I think these changes are warranted.

---

## Changes

### 1. `webcam-fix-book5/install.sh` — Fix kernel version check (line 163)

IPU7 support landed in kernel **6.17**, not 6.18. The current check incorrectly
blocks installation on distros shipping kernel 6.17.x (Ubuntu 25.10, Zorin OS 18.1).

**Before:**
```bash
if [[ "$KMAJOR" -lt 6 ]] || { [[ "$KMAJOR" -eq 6 ]] && [[ "$KMINOR" -lt 18 ]]; }; then
```

**After:**
```bash
if [[ "$KMAJOR" -lt 6 ]] || { [[ "$KMAJOR" -eq 6 ]] && [[ "$KMINOR" -lt 17 ]]; }; then
```

**Affected distros confirmed working on kernel 6.17:**
- Ubuntu 25.10 — kernel 6.17.0-22-generic
- Zorin OS 18.1 — kernel 6.17.0-20-generic

---

### 2. `webcam-fix-book5/libcamera-bayer-fix/build-patched-libcamera.sh` — Add missing distros to `detect_distro()` (lines 140, 148)

`detect_distro()` has explicit case entries for common distros. Two tested distros
are missing and fall through to `DISTRO="unknown"`, causing dependency installation
to be skipped with a warning.

**Line 140 — add `zorin`:**

Zorin OS 18.1 has `ID=zorin` in `/etc/os-release`. It is Ubuntu 24.04-based and
uses apt — it should map to `DISTRO="debian"` alongside the other Ubuntu/Debian
derivatives.

```bash
# Before:
ubuntu|debian|linuxmint|pop)

# After:
ubuntu|debian|linuxmint|pop|zorin)
```

**Line 148 — add `cachyos`:**

CachyOS has `ID=cachyos` in `/etc/os-release`. It is Arch-based and uses pacman —
it should map to `DISTRO="arch"` alongside the other Arch derivatives.

```bash
# Before:
arch|manjaro|endeavouros)

# After:
arch|manjaro|endeavouros|cachyos)
```

---
---

## Background

We are developing a companion script (`webcam-full.sh`) that sits alongside
`install.sh` and handles the additional setup needed to get the webcam fix working
across a range of Linux distributions — including those that don't ship a usable
libcamera version (>= 0.6.0) and require a source build.

The script automates:
- IPU7 kernel support packages per distro
- libcamera source build (v0.7.0) and PipeWire SPA plugin where repo version is
  too old
- AppIndicator library for the camera-relay systray icon
- GNOME appindicator extension setup
- Systray autostart
- Calls `install.sh` at the end (dropped to normal user privileges)

Testing so far across multiple distros surfaced the two issues above.

---

## Test results for webcam-full.sh

| Distro | Kernel | libcamera | Desktop | Status |
|--------|--------|-----------|---------|--------|
| Fedora 44 | 6.19.12-300.fc44 | 0.7.0 (repo) | KDE 6.6.3 | ✓ Working |
| Ubuntu 25.10 | 6.17.0-22-generic | 0.7.0 (source-built) | GNOME 49 | ✓ Working |
| Ubuntu 26.04 | 7.0.0-12-generic | 0.7.0 (repo) | GNOME 50 / KDE 6.6.4 | ✓ Working |
| Arch / EndeavourOS | 6.19.7-arch1-1 | 0.7.0 (repo) | KDE 6.6.4 / GNOME 50 | ✓ Working |
| Debian 13.4.0 | 6.19.10+deb13 (backports) | 0.7.0 (source-built) | KDE | ⚠ Scripts working, camera blocked¹ |
| Zorin OS 18.1 | 6.17.0-20-generic | 0.7.0 (source-built) | GNOME 46 | ✓ Working |
| CachyOS | 6.19.12-1-cachyos | 0.7.0-3.1 (repo) | KDE 6.6.4 | ✓ Working |
| Linux Mint | pending | TBD | Cinnamon | Pending |

¹ Debian 13 camera blocked: `CONFIG_VIDEO_INTEL_IPU7` disabled in all Debian
kernels including backports (bug #1118639, filed Oct 2025, unresolved).
Everything installs and builds correctly — camera will work once Debian enables
this config option.
