### PR TITLE
Fix ipu-bridge-fix DKMS version mismatch for webcam-fix-book5

### DIFF
--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -30,6 +30,8 @@ VISION_DRIVER_REPO="https://github.com/intel/vision-drivers"
 VISION_DRIVER_BRANCH="main"
 SRC_DIR="/usr/src/vision-driver-${VISION_DRIVER_VER}"
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 FORCE=false
 [ "$1" = "--force" ] && FORCE=true
 
@@ -397,11 +399,10 @@ if [[ "$DMI_VENDOR" == "SAMSUNG ELECTRONICS CO., LTD." ]]; then
     esac
 fi
 
-IPU_BRIDGE_FIX_VER="1.1"
+IPU_BRIDGE_FIX_VER=$(grep "^PACKAGE_VERSION=" "$SCRIPT_DIR/ipu-bridge-fix/dkms.conf"     | cut -d= -f2 | tr -d '"')
 IPU_BRIDGE_FIX_SRC="/usr/src/ipu-bridge-fix-${IPU_BRIDGE_FIX_VER}"
 
 if $NEEDS_ROTATION_FIX; then
-    SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
     # Check if already installed and working
     if dkms status "ipu-bridge-fix/${IPU_BRIDGE_FIX_VER}" 2>/dev/null | grep -q "installed"; then
@@ -502,7 +503,7 @@ if [[ "$SENSOR" == "ov02e10" ]] && $NEEDS_ROTATION_FIX; then
         echo "  OV02E10 + rotation fix detected — building patched libcamera..."
         echo "  (This fixes purple/magenta tint caused by bayer pattern mismatch)"
         echo ""
-        SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+        # SCRIPT_DIR set at top of script
         if sudo "$SCRIPT_DIR/libcamera-bayer-fix/build-patched-libcamera.sh"; then
             echo "  ✓ Patched libcamera installed (bayer order fix)"
         else

--- a/webcam-fix-book5/ipu-bridge-check-upstream.sh
+++ b/webcam-fix-book5/ipu-bridge-check-upstream.sh
@@ -9,7 +9,9 @@
 #   - Next reboot uses the native kernel module instead
 
 DKMS_NAME="ipu-bridge-fix"
-DKMS_VER="1.0"
+# Detect installed version from DKMS rather than hardcoding — the installed
+# version may differ from what this script was originally shipped with.
+DKMS_VER=$(dkms status 2>/dev/null     | grep "^${DKMS_NAME}"     | grep -oP "${DKMS_NAME}/\K[0-9.]+"     | head -1 || true)
 
 log() { echo "ipu-bridge-check: $*"; }
 

--- a/webcam-fix-book5/uninstall.sh
+++ b/webcam-fix-book5/uninstall.sh
@@ -7,7 +7,9 @@ set -e
 
 VISION_DRIVER_VER="1.0.0"
 SRC_DIR="/usr/src/vision-driver-${VISION_DRIVER_VER}"
-IPU_BRIDGE_FIX_VER="1.1"
+# Detect installed ipu-bridge-fix version from DKMS rather than hardcoding —
+# the installed version may differ from the version in the current source tree.
+IPU_BRIDGE_FIX_VER=$(dkms status 2>/dev/null     | grep "^ipu-bridge-fix"     | grep -oP 'ipu-bridge-fix/\K[0-9.]+'     | head -1 || true)
 IPU_BRIDGE_FIX_SRC="/usr/src/ipu-bridge-fix-${IPU_BRIDGE_FIX_VER}"
 
 echo "=============================================="
@@ -41,7 +43,10 @@ fi
 # [3/11] Remove ipu-bridge-fix DKMS module (camera rotation fix)
 echo "[3/11] Removing ipu-bridge-fix DKMS module..."
 IPU_BRIDGE_REMOVED=false
-for ver in "$IPU_BRIDGE_FIX_VER" "1.0"; do
+# Build list of versions to check: dynamically detected version + known legacy versions
+IPU_BRIDGE_VERSIONS=("1.0")
+[[ -n "$IPU_BRIDGE_FIX_VER" ]] && IPU_BRIDGE_VERSIONS=("$IPU_BRIDGE_FIX_VER" "1.0")
+for ver in "${IPU_BRIDGE_VERSIONS[@]}"; do
     if dkms status "ipu-bridge-fix/${ver}" 2>/dev/null | grep -q "ipu-bridge-fix"; then
         sudo dkms remove "ipu-bridge-fix/${ver}" --all 2>/dev/null || true
         IPU_BRIDGE_REMOVED=true
@@ -156,7 +161,7 @@ while IFS=: read -r user _ _ _ _ home _; do
     service_file="$home/.config/systemd/user/camera-relay.service"
     if [[ -f "$service_file" ]]; then
         sudo -u "$user" systemctl --user disable camera-relay.service 2>/dev/null || true
-        rm -f "$service_file"
+        sudo -u "$user" rm -f "$service_file"
     fi
 done < <(getent passwd)
 sudo rm -f /usr/local/bin/camera-relay


### PR DESCRIPTION
# PR: Fix ipu-bridge-fix DKMS version mismatch for webcam-fix-book5

## Summary

Fixes a version mismatch bug where `webcam-fix-book5/install.sh` and `webcam-fix-book5/uninstall.sh` hardcode `ipu-bridge-fix` version `"1.1"`, and `webcam-fix-book5/ipu-bridge-check-upstream.sh` hardcodes `"1.0"`, but the recent ipu-bridge-fix tarball update changed `dkms.conf` to declare `PACKAGE_VERSION="1.2"`. This causes DKMS to register the module under a different version than the scripts expect, silently breaking uninstall. Also fixes a privilege issue in the camera-relay service file removal, and moves `SCRIPT_DIR` detection to the top of `webcam-fix-book5/install.sh`.

---

## Problems

### 1. ipu-bridge-fix version mismatch webcam-fix-book5 (install.sh, uninstall.sh, ipu-bridge-check-upstream.sh)

`webcam-fix-book5/install.sh` hardcodes `IPU_BRIDGE_FIX_VER="1.1"` but the `webcam-fix-book5/ipu-bridge-fix/dkms.conf` now declares `PACKAGE_VERSION="1.2"`.

**What happens on install:**

1. Source files (containing `PACKAGE_VERSION="1.2"` in `dkms.conf`) are copied to `/usr/src/ipu-bridge-fix-1.1/`
2. `dkms add "ipu-bridge-fix/1.1"` is called — but DKMS reads the version from `dkms.conf` and registers the module as `ipu-bridge-fix/1.2`
3. The `dkms build` and `dkms install` commands reference version `1.1` which DKMS does not recognise — the build may fail or produce unpredictable results

**What happens on uninstall:**

- `webcam-fix-book5/uninstall.sh` hardcodes `IPU_BRIDGE_FIX_VER="1.1"` and checks versions `"1.1"` and `"1.0"` — but `1.2` is what DKMS actually has registered
- Neither check matches — `dkms remove` is never called
- The DKMS module is **silently left installed** after uninstall
- On the next kernel upgrade, DKMS `AUTOINSTALL="yes"` rebuilds the module for the new kernel even though the user has uninstalled the fix

**What happens when native kernel gets the fix:**

- `ipu-bridge-check-upstream.sh` hardcodes `DKMS_VER="1.0"`
- When upstream is detected, it tries to remove `ipu-bridge-fix/1.0` — not found, so the DKMS module is again left behind permanently

### 2. camera-relay service file was not removed as correct user (uninstall.sh) from previous PR.

The  `webcam-fix-book5/uninstall.sh` uses:

```bash
sudo -u "$user" systemctl --user disable camera-relay.service 2>/dev/null || true
rm -f "$service_file"
```

The `systemctl --user disable` is correctly run as the user, but the subsequent `rm -f "$service_file"` runs as root. Since `~/.config/systemd/user/camera-relay.service` is owned by the user, the removal works but is inconsistent — root should not be removing files from user home directories directly. The correct approach is:

```bash
sudo -u "$user" systemctl --user disable camera-relay.service 2>/dev/null || true
sudo -u "$user" rm -f "$service_file"
```

---

## Fixes

### install.sh

**1. Move `SCRIPT_DIR` to top of script** alongside other variable declarations — available throughout without fallback needed:

```bash
SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
```

**2. Read `IPU_BRIDGE_FIX_VER` dynamically from `dkms.conf`** — always in sync with the actual source, no manual update required when version bumps:

```bash
IPU_BRIDGE_FIX_VER=$(grep "^PACKAGE_VERSION=" "$SCRIPT_DIR/ipu-bridge-fix/dkms.conf" \
    | cut -d= -f2 | tr -d '"')
```

**3. Remove `SCRIPT_DIR` fallback** in bayer fix section — no longer needed.

### uninstall.sh

**1. Detect installed version from DKMS** rather than hardcoding:

```bash
IPU_BRIDGE_FIX_VER=$(dkms status 2>/dev/null \
    | grep "^ipu-bridge-fix" \
    | grep -oP 'ipu-bridge-fix/\K[0-9.]+' \
    | head -1 || true)
```

**2. Update removal loop** to use dynamically detected version plus legacy
fallback, handling the case where no version is detected:

```bash
IPU_BRIDGE_VERSIONS=("1.0")
[[ -n "$IPU_BRIDGE_FIX_VER" ]] && IPU_BRIDGE_VERSIONS=("$IPU_BRIDGE_FIX_VER" "1.0")
for ver in "${IPU_BRIDGE_VERSIONS[@]}"; do
    ...
done
```

**3. Fix camera-relay service file removal** to run as the correct user:

```bash
sudo -u "$user" rm -f "$service_file"
```

### ipu-bridge-check-upstream.sh

**Detect installed version from DKMS** rather than hardcoding `"1.0"`:

```bash
DKMS_VER=$(dkms status 2>/dev/null \
    | grep "^${DKMS_NAME}" \
    | grep -oP "${DKMS_NAME}/\K[0-9.]+" \
    | head -1 || true)
```

---

## Additional note — DMI fallback in ipu-bridge-check-upstream.sh (Not Fixed)

Line 35:

```bash
DMI_PRODUCT=$(cat /sys/class/dmi/id/product_name 2>/dev/null || echo "940XHA")
```

If the DMI read fails, this falls back to `"940XHA"` (a specific Samsung model). On a machine where the DMI read fails but the native kernel does not have the Samsung rotation fix, the script could incorrectly conclude the fix is present, remove the DKMS workaround, and break the camera. A safer approach would be to exit without removing anything if `DMI_PRODUCT` is empty.

---

## Files changed

- `webcam-fix-book5/install.sh` — `SCRIPT_DIR` moved to top; `IPU_BRIDGE_FIX_VER` read dynamically from `dkms.conf`; bayer fix `SCRIPT_DIR` fallback removed
- `webcam-fix-book5/uninstall.sh` — `IPU_BRIDGE_FIX_VER` detected from DKMS;
  removal loop updated; camera-relay service removal fixed to use correct user
- `webcam-fix-book5/ipu-bridge-check-upstream.sh` — `DKMS_VER` detected from
  DKMS rather than hardcoded
