### PR TITLE
webcam-fix-libcamera: install AppIndicator GIR + autostart for systray

### DIFF
--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1205,15 +1205,30 @@ if [[ -d "$RELAY_DIR" ]]; then
     sudo chmod 755 /usr/local/bin/camera-relay
     echo "  ✓ Installed /usr/local/bin/camera-relay"
 
+    # Install systray runtime dependency (Python AppIndicator binding)
+    case "$DISTRO" in
+        ubuntu|debian)
+            sudo apt-get install -y --no-install-recommends \
+                gir1.2-ayatanaappindicator3-0.1 2>/dev/null \
+                && echo "  ✓ Installed gir1.2-ayatanaappindicator3-0.1 (systray binding)" \
+                || echo "  ⚠ Could not install gir1.2-ayatanaappindicator3-0.1 — systray icon will not appear"
+            ;;
+    esac
+
     # Install systray GUI
     sudo mkdir -p /usr/local/share/camera-relay
     sudo cp "$RELAY_DIR/camera-relay-systray.py" /usr/local/share/camera-relay/
     sudo chmod 755 /usr/local/share/camera-relay/camera-relay-systray.py
     echo "  ✓ Installed systray GUI"
 
-    # Install desktop file
+    # Install desktop file (app menu entry)
     sudo cp "$RELAY_DIR/camera-relay-systray.desktop" /usr/share/applications/
     echo "  ✓ Installed desktop entry"
+
+    # Install autostart entry so the systray launches on login
+    sudo install -m 644 "$RELAY_DIR/camera-relay-systray.desktop" \
+        /etc/xdg/autostart/camera-relay-systray.desktop
+    echo "  ✓ Installed autostart entry (/etc/xdg/autostart/)"
 
     # Auto-enable persistent on-demand relay
     echo "  Enabling on-demand relay (auto-starts on login)..."

--- a/webcam-fix-libcamera/uninstall.sh
+++ b/webcam-fix-libcamera/uninstall.sh
@@ -32,6 +32,9 @@ sudo rm -f /etc/modprobe.d/99-camera-relay-loopback.conf
 sudo rm -f /etc/modules-load.d/v4l2loopback.conf
 sudo rm -rf /usr/local/share/camera-relay
 sudo rm -f /usr/share/applications/camera-relay-systray.desktop
+sudo rm -f /etc/xdg/autostart/camera-relay-systray.desktop
+# Stop any running systray instance from this install
+pkill -f "camera-relay-systray.py" 2>/dev/null || true
 # Remove user service file if still present
 rm -f "${HOME}/.config/systemd/user/camera-relay.service" 2>/dev/null || true
 


### PR DESCRIPTION
## Problem

After running `webcam-fix-libcamera/install.sh` on Ubuntu 26.04 with GNOME 50.1 (Wayland), the camera-relay tray icon never appears, even though `camera-relay.service` is active and the relay works correctly when an app opens the device.

Root cause is two independent bugs:

1. **Missing Python AppIndicator binding.** The installer doesn't install `gir1.2-ayatanaappindicator3-0.1`. With only the C library `libayatana-appindicator3-1` present (pulled in transitively), `camera-relay-systray.py:34-43` fails the `import` and falls back to `Gtk.StatusIcon`. On GNOME ≥ 40 / Wayland, `Gtk.StatusIcon` is non-functional and emits `Gtk-CRITICAL ** gtk_widget_get_scale_factor: assertion 'GTK_IS_WIDGET (widget)' failed`.
2. **No autostart.** The `.desktop` file is copied only to `/usr/share/applications/` (so it's in the app menu), but never to `/etc/xdg/autostart/` and there's no systemd-user unit, so the systray is never launched on login.

## Fix

- Install `gir1.2-ayatanaappindicator3-0.1` in the Ubuntu/Debian branch of `install.sh`. Failure to install only emits a warning (doesn't block the rest of the install).
- Install the same `.desktop` file additionally to `/etc/xdg/autostart/` so GNOME/KDE/etc. start the systray at user login.
- `uninstall.sh` now removes the autostart entry and `pkill`s any running systray instance.

## Scope intentionally limited

- **Ubuntu/Debian only.** I don't have a Fedora or Arch system to test against. Equivalent runtime packages are likely `libayatana-appindicator-gtk3` (Fedora) and `libayatana-appindicator` (Arch); leaving for a follow-up by someone who can validate.
- **`webcam-fix-book5/install.sh` not patched.** Same code pattern, same systray, almost certainly the same bug — but I don't have Lunar Lake hardware to validate. Follow-up needed to apply the same fix there after testing.
- **`Gtk.StatusIcon` fallback in `camera-relay-systray.py` left untouched.** It's dead code on modern GNOME and would be cleaner to remove or rework, but that's a separate change; this PR sticks to the minimum to get the icon working.

## Tested on

- Samsung Galaxy Book4 Ultra (DMI `960XGL`, Meteor Lake H)
- Ubuntu 26.04 LTS "Resolute Raccoon"
- GNOME Shell 50.1, Wayland session
- Extension `ubuntu-appindicators@ubuntu.com` enabled

## Verification

After applying the fix on the test machine:

```
$ dpkg -l gir1.2-ayatanaappindicator3-0.1 | tail -1
ii  gir1.2-ayatanaappindicator3-0.1 0.5.94-1build1 amd64        Typelib files for libayatana-appindicator3-1 (GTK-3+ version)

$ ls /etc/xdg/autostart/camera-relay-systray.desktop
/etc/xdg/autostart/camera-relay-systray.desktop

$ pgrep -af camera-relay-systray.py
15599 python3 /usr/local/share/camera-relay/camera-relay-systray.py
```

Tray icon visible in GNOME top bar; menu actions (Start/Stop/persistent) work as expected.