### PR TITLE
Fix alc298 amp init service for Book3 Pro 14

### DIFF
--- a/speaker-fix-940xfg/99-alc298-amp-init.rules
+++ b/speaker-fix-940xfg/99-alc298-amp-init.rules
@@ -1,0 +1,11 @@
+# Samsung Galaxy Book3 Pro 14" (940XFG) — start the ALC298 amp init as soon as
+# the sound card is fully registered.
+#
+# Why controlC? and not hwC?D?: /dev/snd/hwC*D* is never tagged for systemd
+# (99-systemd.rules tags controlC* only), which is what made the .device
+# dependency in this PR unsatisfiable. controlC* is created by
+# snd_card_register(), i.e. after every codec's hwdep node has been built, so
+# it is a guaranteed-late trigger with no card-index assumption baked in.
+# alc298-amp-init.sh does the real vendor_id/subsystem_id matching and exits 0
+# when the codec isn't ours, so firing on a second sound card is harmless.
+ACTION=="add", SUBSYSTEM=="sound", KERNEL=="controlC?", TAG+="systemd", ENV{SYSTEMD_WANTS}+="alc298-amp-init.service"

--- a/speaker-fix-940xfg/README.md
+++ b/speaker-fix-940xfg/README.md
@@ -43,7 +43,7 @@ This is **not** a kernel module. It does not patch `snd-hda-codec-realtek`.
 It is a userspace fix:
 
 - One bash script that talks to the codec via `hda-verb` (from `alsa-tools`)
-- One systemd unit that runs the script at boot
+- One systemd unit, activated by udev when the sound card registers (not enabled at boot)
 - One `system-sleep` hook that re-runs it after resume from suspend
 
 That keeps the fix entirely outside the kernel module hierarchy: it survives
@@ -74,7 +74,7 @@ The installer will:
 1. Verify the DMI product is `940XFG` and a codec with SSID `0x144dc882` is present.
 2. Install `alsa-tools` if `hda-verb` is missing.
 3. Copy `alc298-amp-init.sh` to `/usr/local/sbin/`.
-4. Install and enable `alc298-amp-init.service` (runs at every boot).
+4. Install `alc298-amp-init.service` and the udev rule that starts it as soon as the sound card registers (`controlC*` node appears) — not enabled at boot.
 5. Install `/lib/systemd/system-sleep/alc298-amp-init` (re-runs after suspend/resume).
 6. Fire the script once so speakers work immediately, no reboot required.
 

--- a/speaker-fix-940xfg/alc298-amp-init.service
+++ b/speaker-fix-940xfg/alc298-amp-init.service
@@ -1,14 +1,16 @@
 [Unit]
 Description=Initialize ALC298 internal speaker amps (Samsung Galaxy Book3 Pro 14" / 940XFG)
 Documentation=https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/44
-Requires=dev-snd-hwC0D0.device
-After=systemd-modules-load.service sound.target dev-snd-hwC0D0.device
-Wants=sound.target 
+After=systemd-modules-load.service
 
 [Service]
 Type=oneshot
 RemainAfterExit=yes
 ExecStart=/usr/local/sbin/alc298-amp-init.sh
 
-[Install]
-WantedBy=multi-user.target
+# Deliberately no [Install] section — udev starts this unit when the sound card
+# registers (see /etc/udev/rules.d/99-alc298-amp-init.rules). Adding
+# WantedBy=multi-user.target back would reintroduce the original bug: the boot
+# transaction can start the unit before the codec exists, the script no-ops,
+# and RemainAfterExit=yes then leaves it active so udev's later trigger does
+# nothing at all.

--- a/speaker-fix-940xfg/alc298-amp-init.service
+++ b/speaker-fix-940xfg/alc298-amp-init.service
@@ -1,9 +1,9 @@
 [Unit]
 Description=Initialize ALC298 internal speaker amps (Samsung Galaxy Book3 Pro 14" / 940XFG)
 Documentation=https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/44
-After=systemd-modules-load.service sound.target
-Wants=sound.target
-ConditionPathExists=/dev/snd/hwC0D0
+Requires=dev-snd-hwC0D0.device
+After=systemd-modules-load.service sound.target dev-snd-hwC0D0.device
+Wants=sound.target 
 
 [Service]
 Type=oneshot

--- a/speaker-fix-940xfg/install.sh
+++ b/speaker-fix-940xfg/install.sh
@@ -131,8 +131,11 @@ echo "Installing system-sleep resume hook..."
 mkdir -p /lib/systemd/system-sleep
 install -m 755 "${SCRIPT_DIR}/alc298-amp-init-sleep.sh"  /lib/systemd/system-sleep/alc298-amp-init
 
+echo "Installing udev rule..."
+install -m 644 "${SCRIPT_DIR}/99-alc298-amp-init.rules" /etc/udev/rules.d/99-alc298-amp-init.rules
+
 systemctl daemon-reload
-systemctl enable alc298-amp-init.service
+udevadm control --reload-rules
 
 # ---------------------------------------------------------------------------
 # Fire once now so the user has working speakers without rebooting

--- a/speaker-fix-940xfg/uninstall.sh
+++ b/speaker-fix-940xfg/uninstall.sh
@@ -17,8 +17,10 @@ echo "Removing installed files..."
 rm -f /usr/local/sbin/alc298-amp-init.sh
 rm -f /etc/systemd/system/alc298-amp-init.service
 rm -f /lib/systemd/system-sleep/alc298-amp-init
+rm -f /etc/udev/rules.d/99-alc298-amp-init.rules
 
 systemctl daemon-reload
+udevadm control --reload-rules
 
 echo ""
 echo "=== Uninstall complete ==="


### PR DESCRIPTION
Previously, the service was failing on boot. This happened because systemd would attempt to run the script before the kernel had fully prepared the sound card. Systemd will now actively wait for the specific audio device node (/dev/snd/hwC0D0) to appear before it tries to execute the script.