### PR TITLE
camera-relay: fix black camera on hybrid-GPU laptops (EGL debayer lands on NVIDIA)

### DIFF
--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -935,6 +935,104 @@ cmd_doctor() {
         fi
     fi
 
+    # The Software ISP debayers on the GPU via EGL, and on a hybrid laptop GLVND
+    # hands it the NVIDIA driver, which it cannot use. Everything else in this
+    # report stays green while that happens, which is exactly what made this so
+    # hard to place — so name the GPU explicitly.
+    echo
+    echo "── GPU / EGL debayer ──"
+    local gst_log="$rt/camera-relay-gst.log"
+    local gpu_debayer_failed=false hybrid_unpinned=false
+    local nodes_seen=0 saw_nvidia=false saw_mesa_drv=false
+    local rn_base rn_drv
+    while read -r rn_base rn_drv; do
+        [[ -n "$rn_base" ]] || continue
+        nodes_seen=$((nodes_seen + 1))
+        echo "  render node: /dev/dri/$rn_base (driver $rn_drv)"
+        case "$rn_drv" in
+            nvidia|nvidia-drm) saw_nvidia=true ;;
+            unknown) ;;
+            *) saw_mesa_drv=true ;;
+        esac
+    done < <(render_node_drivers)
+    (( nodes_seen == 0 )) && echo "  render node: NONE — no /dev/dri/renderD*, the GPU debayer cannot run at all"
+
+    local vd vf
+    for vd in /etc/glvnd/egl_vendor.d /usr/share/glvnd/egl_vendor.d; do
+        [[ -d "$vd" ]] || continue
+        for vf in "$vd"/*.json; do
+            [[ -f "$vf" ]] || continue
+            echo "  EGL vendor ICD: $vf ($(grep -oP '"library_path"\s*:\s*"\K[^"]+' "$vf" 2>/dev/null | head -1 || echo '?'))"
+        done
+    done
+
+    # GLVND loads these in the order printed above, so an NVIDIA ICD sorting
+    # first is not a curiosity — it is the bug.
+    local want_pin="" unit_pin="" env_pin="${__EGL_VENDOR_LIBRARY_FILENAMES:-}"
+    want_pin=$(detect_egl_vendor_pin) || want_pin=""
+    if systemctl --user cat "$SERVICE_NAME" &>/dev/null; then
+        unit_pin=$(systemctl --user cat "$SERVICE_NAME" 2>/dev/null \
+            | grep -oP '^Environment=__EGL_VENDOR_LIBRARY_FILENAMES=\K.*' | tail -1) || unit_pin=""
+    fi
+    if $saw_nvidia && $saw_mesa_drv; then
+        echo "  topology: HYBRID (NVIDIA dGPU + Mesa-driven iGPU)"
+    elif $saw_nvidia; then
+        echo "  topology: NVIDIA only"
+    elif (( nodes_seen > 0 )); then
+        echo "  topology: single Mesa-driven GPU — no vendor pin needed"
+    fi
+    echo "  vendor pin (this shell):   ${env_pin:-none}"
+    echo "  vendor pin (service unit): ${unit_pin:-none}"
+    if [[ -n "$want_pin" && -z "$unit_pin" ]]; then
+        hybrid_unpinned=true
+        echo "  → HYBRID GPU WITH NO PIN. GLVND loads the NVIDIA ICD first, so the"
+        echo "    Software ISP's EGL debayer runs on NVIDIA's driver and fails."
+        echo "    Fix: camera-relay disable-persistent && camera-relay enable-persistent"
+        echo "    (or drop in Environment=__EGL_VENDOR_LIBRARY_FILENAMES=$want_pin)"
+    fi
+
+    # What the pipeline actually got, rather than what it should have got.
+    # Both logs, because the pipeline lives in a different process per mode:
+    # always-on runs gst-launch from start_pipeline() into camera-relay-gst.log,
+    # while on-demand — the default — runs it under camera-relay-monitor and
+    # everything lands in camera-relay.log. Reading only the first one missed
+    # libcamera's EGL banner, and the debayer failure, in the common mode.
+    local pipe_logs=() lf_egl
+    for lf_egl in "$gst_log" "$rt/camera-relay.log"; do
+        [[ -s "$lf_egl" ]] && pipe_logs+=("$lf_egl")
+    done
+    if (( ${#pipe_logs[@]} == 0 )); then
+        echo "  pipeline EGL: no relay log yet — start the relay and retry"
+    else
+        local egl_lines bench_line
+        egl_lines=$(grep -haoE '(EGL_VENDOR|EGL_VERSION|GL_VERSION|GL_RENDERER):.*' \
+            "${pipe_logs[@]}" 2>/dev/null | tail -4) || egl_lines=""
+        if [[ -n "$egl_lines" ]]; then
+            echo "  pipeline EGL (from ${pipe_logs[*]}):"
+            printf '%s\n' "$egl_lines" | sed 's/^/    /'
+        else
+            echo "  pipeline EGL: not reported in ${pipe_logs[*]}"
+            echo "    (CPU debayer, or the pipeline never got that far)"
+        fi
+        # Proof that frames are really going through the debayer, not just that
+        # it initialised — libcamera prints this once it has processed a batch.
+        bench_line=$(grep -ha 'Debayer processed' "${pipe_logs[@]}" 2>/dev/null | tail -1) || bench_line=""
+        [[ -n "$bench_line" ]] && echo "  debayer throughput: ${bench_line#*INFO }"
+        if grep -haq 'debayerGPU failed\|glFrameBufferTexture2D error' "${pipe_logs[@]}" 2>/dev/null; then
+            gpu_debayer_failed=true
+            echo "  → GPU DEBAYER FAILED — this is why no picture reaches the loopback:"
+            { grep -ha 'debayerGPU failed\|glFrameBufferTexture2D error' "${pipe_logs[@]}" 2>/dev/null \
+                | tail -3 | sed 's/^/    /'; } || true
+            echo "    The sensor still powers on (privacy LED lit) and the relay still"
+            echo "    reports STREAMING, but every frame is dropped in Bayer→RGB."
+            if [[ -n "$want_pin" ]]; then
+                echo "    Fix: pin EGL to the iGPU — $want_pin"
+            else
+                echo "    Fix: LIBCAMERA_SOFTISP_MODE=cpu in the service unit (slower, always works)"
+            fi
+        fi
+    fi
+
     echo
     echo "── v4l2loopback ──"
     # The module's reference count is the cheapest proof that something really
@@ -997,9 +1095,22 @@ cmd_doctor() {
             --stream-to=- 2>/dev/null | tail -c 262144 > "$frame" || true
         local size=0
         [[ -f "$frame" ]] && size=$(stat -c %s "$frame" 2>/dev/null || echo 0)
+        # A black picture with the relay "up" is the signature of the hybrid-GPU
+        # debayer failure, so say so here instead of leaving it to the reader to
+        # connect this section with the EGL one.
+        gpu_note() {
+            if $gpu_debayer_failed; then
+                echo "  → CAUSE: the GPU debayer failed (see 'GPU / EGL debayer' above)."
+                echo "    Nothing is wrong with the sensor or the loopback."
+            elif $hybrid_unpinned; then
+                echo "  → LIKELY CAUSE: hybrid GPU with no EGL vendor pin (see above)."
+                echo "    Re-run 'camera-relay enable-persistent' and check again."
+            fi
+        }
         if (( size == 0 )); then
             echo "  NO FRAMES — the device exists but nothing is writing to it."
             echo "  → the relay is not feeding the loopback. Check the logs below."
+            gpu_note
         else
             local distinct
             distinct=$(od -An -tu1 "$frame" 2>/dev/null | tr -s ' ' '\n' \
@@ -1008,12 +1119,14 @@ cmd_doctor() {
                 echo "  BLANK FRAMES — $size bytes captured, only $distinct distinct byte values."
                 echo "  → apps can open the device but the picture is uniform (black)."
                 echo "    The relay is holding the device open; the camera pipeline is not producing."
+                gpu_note
             else
                 echo "  REAL PICTURE — $size bytes captured, $distinct distinct byte values."
                 echo "  → the relay side is working end to end. If a browser still shows no"
                 echo "    camera, the problem is browser-side (see below), not the relay."
             fi
         fi
+        unset -f gpu_note
         rm -f "$frame"
     fi
 

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -1276,9 +1276,17 @@ cmd_enable_persistent() {
     # Deliberately exclusive. Setting both would leave CPU mode winning (it uses
     # no EGL at all) and the pin dead in the unit on exactly the hybrid machines
     # it was written for.
+    #
+    # Not choosing cpu is not enough to get gpu, though: the installers write
+    # LIBCAMERA_SOFTISP_MODE=cpu to /etc/environment.d for the PipeWire-libcamera
+    # path, systemd's 30-systemd-environment-d-generator feeds that into the user
+    # manager, and this service inherits it — which would make the pin inert
+    # exactly here. A unit-level Environment= outranks the inherited value, so
+    # the hybrid branch has to state gpu rather than merely stay silent.
     local egl_vendor=""
     egl_vendor=$(detect_egl_vendor_pin) || egl_vendor=""
     if [[ -n "$egl_vendor" ]]; then
+        softisp_mode="gpu"
         info "Hybrid GPU detected — service will pin EGL to $egl_vendor (GPU debayer on the iGPU)"
     elif command -v glxinfo &>/dev/null && glxinfo 2>/dev/null | grep -qi "opengl renderer.*nvidia"; then
         softisp_mode="cpu"

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -957,12 +957,16 @@ cmd_doctor() {
     done < <(render_node_drivers)
     (( nodes_seen == 0 )) && echo "  render node: NONE — no /dev/dri/renderD*, the GPU debayer cannot run at all"
 
-    local vd vf
+    local vd vf vlib
     for vd in /etc/glvnd/egl_vendor.d /usr/share/glvnd/egl_vendor.d; do
         [[ -d "$vd" ]] || continue
         for vf in "$vd"/*.json; do
             [[ -f "$vf" ]] || continue
-            echo "  EGL vendor ICD: $vf ($(grep -oP '"library_path"\s*:\s*"\K[^"]+' "$vf" 2>/dev/null | head -1 || echo '?'))"
+            # Assigned first, not inlined: `$(grep … | head -1 || echo '?')` binds
+            # the || to head, which exits 0 on empty input, so the fallback never
+            # fires and an ICD with no library_path renders as empty parens.
+            vlib=$(grep -oP '"library_path"\s*:\s*"\K[^"]+' "$vf" 2>/dev/null | head -1) || vlib=""
+            echo "  EGL vendor ICD: $vf (${vlib:-no library_path})"
         done
     done
 
@@ -983,6 +987,45 @@ cmd_doctor() {
     fi
     echo "  vendor pin (this shell):   ${env_pin:-none}"
     echo "  vendor pin (service unit): ${unit_pin:-none}"
+
+    # The mode decides whether the pin matters at all: LIBCAMERA_SOFTISP_MODE=cpu
+    # skips EGL entirely. The installers write that to /etc/environment.d for the
+    # PipeWire path, systemd's user environment generator feeds it into the user
+    # manager, and this service inherits it — so a pin can be present and inert.
+    # Report all three layers, because only the effective one is the answer.
+    local unit_mode="" inherited_mode="" mode_file="" mf effective_mode
+    if systemctl --user cat "$SERVICE_NAME" &>/dev/null; then
+        unit_mode=$(systemctl --user cat "$SERVICE_NAME" 2>/dev/null \
+            | grep -oP '^Environment=LIBCAMERA_SOFTISP_MODE=\K.*' | tail -1) || unit_mode=""
+    fi
+    inherited_mode=$(systemctl --user show-environment 2>/dev/null \
+        | grep -oP '^LIBCAMERA_SOFTISP_MODE=\K.*' | tail -1) || inherited_mode=""
+    [[ -z "$inherited_mode" ]] && inherited_mode="${LIBCAMERA_SOFTISP_MODE:-}"
+    for mf in /etc/environment.d/*.conf "$HOME/.config/environment.d"/*.conf; do
+        [[ -f "$mf" ]] || continue
+        if grep -q '^LIBCAMERA_SOFTISP_MODE=' "$mf" 2>/dev/null; then
+            mode_file="$mf"
+            break
+        fi
+    done
+    if [[ -n "$unit_mode" ]]; then
+        effective_mode="$unit_mode (from the service unit)"
+    elif [[ -n "$inherited_mode" ]]; then
+        effective_mode="$inherited_mode (inherited${mode_file:+ from $mode_file})"
+    else
+        effective_mode="gpu (libcamera default, nothing set)"
+    fi
+    echo "  debayer mode (service unit): ${unit_mode:-none}"
+    echo "  debayer mode (inherited):    ${inherited_mode:-none}${mode_file:+  ($mode_file)}"
+    echo "  debayer mode (effective):    $effective_mode"
+    if [[ -n "$unit_pin" && -z "$unit_mode" && "$inherited_mode" == "cpu" ]]; then
+        echo "  → PIN IS INERT. CPU debayer touches no EGL at all, so the vendor pin"
+        echo "    above has no effect, and you are paying its framerate cost anyway."
+        echo "    The unit needs its own Environment=LIBCAMERA_SOFTISP_MODE=gpu to"
+        echo "    outrank the inherited value:"
+        echo "    camera-relay disable-persistent && camera-relay enable-persistent"
+    fi
+
     if [[ -n "$want_pin" && -z "$unit_pin" ]]; then
         hybrid_unpinned=true
         echo "  → HYBRID GPU WITH NO PIN. GLVND loads the NVIDIA ICD first, so the"

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -351,6 +351,93 @@ find_libcamera_gst_plugin() {
     return 1
 }
 
+# ── Hybrid-GPU EGL vendor selection ──────────────────────────────────────────
+#
+# libcamera's Software ISP converts Bayer→RGB on the GPU through EGL
+# (debayer_egl.cpp). *Which* GPU that is comes from GLVND, which loads the
+# vendor ICDs in /usr/share/glvnd/egl_vendor.d in filename order — and NVIDIA's
+# ships as 10_nvidia.json, ahead of Mesa's 50_mesa.json. So on a hybrid laptop
+# (Intel or AMD iGPU + NVIDIA dGPU — every Galaxy Book4 Ultra, and the dGPU
+# Book5 Pro variants) the debayer runs on NVIDIA's proprietary EGL driver, which
+# it is not compatible with:
+#
+#   ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
+#   ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
+#
+# The sensor still powers up — the privacy LED comes on, `status` says
+# STREAMING — but not one frame ever reaches v4l2loopback, so apps show a black
+# picture ("your camera may be blocked" in Google Meet).
+#
+# This hides well interactively: a desktop session usually has EGL already
+# resolved to Mesa, so `cam` from a terminal works and only the systemd service
+# breaks. Pinning __EGL_VENDOR_LIBRARY_FILENAMES makes the choice explicit in
+# both places. The alternative fix, LIBCAMERA_SOFTISP_MODE=cpu, also works but
+# costs a large chunk of the framerate (issue #66) — pin the iGPU instead.
+
+# Render nodes and the kernel driver behind each, as "renderD128 i915" lines.
+render_node_drivers() {
+    local node base link drv
+    for node in /dev/dri/renderD*; do
+        [[ -e "$node" ]] || continue
+        base=$(basename "$node")
+        drv="unknown"
+        if link=$(readlink -f "/sys/class/drm/$base/device/driver" 2>/dev/null) \
+           && [[ -n "$link" ]]; then
+            drv=$(basename "$link")
+        fi
+        echo "$base $drv"
+    done
+    return 0
+}
+
+# The GLVND vendor ICD that dispatches to Mesa, wherever the distro put it.
+# Deliberately not hardcoded to 50_mesa.json: the filename prefix is only a
+# load-order hint and distros renumber it.
+find_mesa_egl_vendor() {
+    local dir f
+    # GLVND reads /etc/glvnd/egl_vendor.d first, then /usr/share; within a
+    # directory, filename order. Match that so we name the file GLVND would use.
+    for dir in /etc/glvnd/egl_vendor.d /usr/share/glvnd/egl_vendor.d; do
+        [[ -d "$dir" ]] || continue
+        for f in "$dir"/*.json; do
+            [[ -f "$f" ]] || continue
+            if grep -q 'libEGL_mesa' "$f" 2>/dev/null; then
+                echo "$f"
+                return 0
+            fi
+        done
+    done
+    return 1
+}
+
+# Echo the EGL vendor ICD to pin for the debayer, or return 1 to leave GLVND
+# alone. Only a genuinely mixed NVIDIA-proprietary + Mesa setup gets a pin:
+# on a single-GPU box it is redundant, and on an NVIDIA-only box pointing at a
+# Mesa ICD that cannot drive the hardware would break a working camera.
+detect_egl_vendor_pin() {
+    local base drv have_nvidia=false mesa_driver="" count=0
+
+    while read -r base drv; do
+        [[ -n "$base" ]] || continue
+        count=$((count + 1))
+        case "$drv" in
+            nvidia|nvidia-drm)  have_nvidia=true ;;
+            unknown|"")         ;;
+            *)                  [[ -n "$mesa_driver" ]] || mesa_driver="$drv" ;;
+        esac
+    done < <(render_node_drivers)
+
+    $have_nvidia || return 1
+    [[ -n "$mesa_driver" ]] || return 1
+    (( count >= 2 )) || return 1
+
+    # Derive the target from the iGPU that is actually present rather than
+    # assuming Mesa: every non-NVIDIA render node we can meet here (i915, xe,
+    # amdgpu, radeon, nouveau) is driven by Mesa's EGL, so the file to pin is
+    # whichever ICD dispatches to libEGL_mesa.
+    find_mesa_egl_vendor
+}
+
 setup_environment() {
     require_gst_tools
 
@@ -445,6 +532,16 @@ $inspect_err}"
     local ipa_path
     if ipa_path=$(detect_ipa_path); then
         export LIBCAMERA_IPA_MODULE_PATH="$ipa_path"
+    fi
+
+    # Keep the GPU debayer off the NVIDIA EGL driver on hybrid laptops. An
+    # explicit setting from the caller always wins — if someone pinned a vendor
+    # by hand, that is the answer they want tested.
+    local egl_vendor
+    if [[ -z "${__EGL_VENDOR_LIBRARY_FILENAMES:-}" ]] \
+       && egl_vendor=$(detect_egl_vendor_pin); then
+        export __EGL_VENDOR_LIBRARY_FILENAMES="$egl_vendor"
+        info "Hybrid GPU detected — pinning EGL to $egl_vendor for the debayer"
     fi
 }
 
@@ -1051,16 +1148,32 @@ cmd_enable_persistent() {
         unset -f gst_inspect_with_env
     fi
 
-    # Detect if NVIDIA is the active EGL renderer. libcamera 0.7.0's GPU debayer
-    # (debayer_egl.cpp) is incompatible with NVIDIA's proprietary EGL driver,
-    # causing black frames. Force CPU debayer on NVIDIA systems.
-    if command -v glxinfo &>/dev/null && glxinfo 2>/dev/null | grep -qi "opengl renderer.*nvidia"; then
+    # Keep libcamera's GPU debayer off NVIDIA's EGL driver, which it cannot use
+    # (debayer_egl.cpp → glFrameBufferTexture2D error 36054 → no frames at all,
+    # while `status` still reads STREAMING). There are two ways to do that, and
+    # they cover different machines:
+    #
+    #   1. Hybrid box (iGPU + NVIDIA dGPU): pin the vendor ICD to the iGPU. The
+    #      service inherits none of the session's EGL state, so GLVND falls back
+    #      to filename order and picks 10_nvidia.json — which is why this breaks
+    #      only under systemd and looks fine when you run `cam` by hand.
+    #   2. No iGPU to fall back to: force CPU debayer. Always works, but costs a
+    #      large chunk of the framerate (issue #66), so it is the second choice.
+    #
+    # Deliberately exclusive. Setting both would leave CPU mode winning (it uses
+    # no EGL at all) and the pin dead in the unit on exactly the hybrid machines
+    # it was written for.
+    local egl_vendor=""
+    egl_vendor=$(detect_egl_vendor_pin) || egl_vendor=""
+    if [[ -n "$egl_vendor" ]]; then
+        info "Hybrid GPU detected — service will pin EGL to $egl_vendor (GPU debayer on the iGPU)"
+    elif command -v glxinfo &>/dev/null && glxinfo 2>/dev/null | grep -qi "opengl renderer.*nvidia"; then
         softisp_mode="cpu"
-        info "NVIDIA GPU detected as active renderer — using CPU debayer"
+        info "NVIDIA GPU detected as active renderer, no iGPU to pin — using CPU debayer"
     elif [[ -d /proc/driver/nvidia ]] && \
          ! { command -v prime-select &>/dev/null && [[ "$(prime-select query 2>/dev/null)" == "intel" ]]; }; then
         softisp_mode="cpu"
-        info "NVIDIA GPU detected — using CPU debayer"
+        info "NVIDIA GPU detected, no iGPU to pin — using CPU debayer"
     fi
 
     # Create systemd user service
@@ -1080,6 +1193,7 @@ ${ipa_path:+Environment=LIBCAMERA_IPA_MODULE_PATH=$ipa_path}
 ${gst_path:+Environment=GST_PLUGIN_PATH=$gst_path}
 ${lib_path:+Environment=LD_LIBRARY_PATH=$lib_path}
 ${softisp_mode:+Environment=LIBCAMERA_SOFTISP_MODE=$softisp_mode}
+${egl_vendor:+Environment=__EGL_VENDOR_LIBRARY_FILENAMES=$egl_vendor}
 
 [Install]
 WantedBy=default.target

--- a/camera-relay/tests/test-egl-vendor-pin.sh
+++ b/camera-relay/tests/test-egl-vendor-pin.sh
@@ -1,0 +1,217 @@
+#!/usr/bin/env bash
+# Regression tests for the hybrid-GPU EGL vendor pin.
+#
+# libcamera's Software ISP debayers through EGL, and GLVND picks the vendor ICD
+# by filename order — NVIDIA's 10_nvidia.json sorts ahead of Mesa's
+# 50_mesa.json. Under systemd (which inherits none of the session's EGL state)
+# the debayer therefore lands on NVIDIA's driver, fails, and the camera goes
+# black with the privacy LED lit and the relay reporting STREAMING.
+#
+# Two things have to hold, and both are easy to break silently:
+#   1. Only a mixed NVIDIA-proprietary + Mesa setup gets a pin. Pinning a Mesa
+#      ICD on an NVIDIA-only box would break a camera that works today.
+#   2. The pin must come with LIBCAMERA_SOFTISP_MODE=gpu on the unit. The
+#      installers write cpu to /etc/environment.d for the PipeWire path, the
+#      user manager inherits it, and cpu touches no EGL — so without the
+#      unit-level override the pin is present and inert.
+#
+# Usage: ./test-egl-vendor-pin.sh
+# Requires no camera hardware, no GPU, and touches no system state.
+
+set -uo pipefail
+
+RELAY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+skip() { echo "  – skipped: $*"; }
+
+# Pull a single function out of the relay script so we can exercise it directly
+# without running the whole command dispatcher.
+extract_fn() {
+    sed -n "/^$1()/,/^}/p" "$RELAY"
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-egl-vendor-pin ($RELAY)"
+
+# ── 1. Topology table ─────────────────────────────────────────────────────────
+# find_mesa_egl_vendor is stubbed to a sentinel so this exercises the *decision*
+# — which topologies deserve a pin — independently of which ICDs the machine
+# running the tests happens to have installed. That separation is the point:
+# detection is keyed on render nodes, not on the presence of 10_nvidia.json, so
+# a box with one i915 node and an NVIDIA ICD lying around is single-GPU.
+echo
+echo "topology → pin decision"
+
+topology_case() {
+    local desc="$1" want="$2" nodes="$3" got rc
+    got=$(
+        set -euo pipefail
+        eval "$(extract_fn detect_egl_vendor_pin)"
+        render_node_drivers() { [[ -n "$nodes" ]] && printf '%s\n' "$nodes"; return 0; }
+        find_mesa_egl_vendor() { echo "MESA_ICD"; }
+        detect_egl_vendor_pin
+    ) && rc=0 || rc=$?
+    local verdict="nopin"
+    [[ $rc -eq 0 && "$got" == "MESA_ICD" ]] && verdict="pin"
+    if [[ "$verdict" == "$want" ]]; then
+        ok "$(printf '%-26s %s' "$desc" "$want")"
+    else
+        bad "$(printf '%-26s expected %s, got %s' "$desc" "$want" "$verdict")"
+    fi
+}
+
+# Single GPU — a pin is redundant at best.
+topology_case "i915 only"          nopin "renderD128 i915"
+topology_case "xe only"            nopin "renderD128 xe"
+topology_case "amdgpu only"        nopin "renderD128 amdgpu"
+# NVIDIA-only: pinning Mesa here would point EGL at a driver that cannot drive
+# the hardware and break a working camera. This one must never regress to "pin".
+topology_case "nvidia only"        nopin "renderD128 nvidia"
+topology_case "two nvidia nodes"   nopin "renderD128 nvidia
+renderD129 nvidia"
+# Both Mesa — no vendor ordering problem to solve.
+topology_case "i915 + nouveau"     nopin "renderD128 i915
+renderD129 nouveau"
+# No GPU at all: the debayer cannot run, but that is not this function's problem.
+topology_case "no render nodes"    nopin ""
+# An unreadable driver link must not be mistaken for a Mesa node.
+topology_case "nvidia + unknown"   nopin "renderD128 nvidia
+renderD129 unknown"
+
+# The mixed case this whole feature exists for.
+topology_case "i915 + nvidia"      pin   "renderD128 i915
+renderD129 nvidia"
+topology_case "amdgpu + nvidia"    pin   "renderD128 amdgpu
+renderD129 nvidia"
+topology_case "xe + nvidia-drm"    pin   "renderD128 xe
+renderD129 nvidia-drm"
+topology_case "i915 + nvidia + unk" pin  "renderD128 i915
+renderD129 nvidia
+renderD130 unknown"
+
+# ── 2. find_mesa_egl_vendor against real ICDs ─────────────────────────────────
+# The target is derived, not hardcoded to 50_mesa.json: the numeric prefix is a
+# GLVND load-order hint and distros renumber it.
+echo
+echo "Mesa ICD discovery"
+
+mesa_icd=$(
+    set -uo pipefail
+    eval "$(extract_fn find_mesa_egl_vendor)"
+    find_mesa_egl_vendor
+) || mesa_icd=""
+
+if [[ -z "$mesa_icd" ]]; then
+    if compgen -G "/usr/share/glvnd/egl_vendor.d/*.json" > /dev/null \
+       || compgen -G "/etc/glvnd/egl_vendor.d/*.json" > /dev/null; then
+        bad "ICDs are installed but no Mesa vendor file was found"
+    else
+        skip "no GLVND vendor ICDs installed on this machine"
+    fi
+else
+    if [[ -f "$mesa_icd" ]] && grep -q 'libEGL_mesa' "$mesa_icd"; then
+        ok "found a real Mesa ICD by content: $mesa_icd"
+    else
+        bad "returned $mesa_icd, which does not dispatch to libEGL_mesa"
+    fi
+fi
+
+# ── 3. What actually lands in the service unit ────────────────────────────────
+# The pairing from the header: a pin without LIBCAMERA_SOFTISP_MODE=gpu is inert
+# on any machine whose /etc/environment.d says cpu, which is exactly the machine
+# the installers write that file on.
+echo
+echo "generated service unit"
+
+# cmd_enable_persistent probes the system hard before it writes anything. Stub
+# every probe so the test is hermetic, point SERVICE_DIR at a temp dir, and
+# neuter systemctl so nothing on the host is enabled or reloaded.
+gen_unit() {
+    local pin="$1" glxinfo_says="$2"
+    local outdir="$TMP/unit-$RANDOM"
+    mkdir -p "$outdir/bin"
+    if [[ -n "$glxinfo_says" ]]; then
+        printf '#!/bin/sh\necho "OpenGL renderer string: %s"\n' "$glxinfo_says" \
+            > "$outdir/bin/glxinfo"
+        chmod +x "$outdir/bin/glxinfo"
+    fi
+    (
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        source "$RELAY" -h >/dev/null 2>&1 || true
+        PATH="$outdir/bin:$PATH"
+        SERVICE_DIR="$outdir"
+        is_persistent() { return 1; }
+        require_gst_tools() { return 0; }
+        detect_ipa_path() { return 1; }
+        detect_gst_plugin_path() { return 1; }
+        detect_libcamera_lib_path() { return 1; }
+        systemctl() { return 0; }
+        if [[ -n "$pin" ]]; then
+            detect_egl_vendor_pin() { echo "$pin"; }
+        else
+            detect_egl_vendor_pin() { return 1; }
+        fi
+        cmd_enable_persistent --yes >/dev/null 2>&1
+    ) || { echo "GENERATION FAILED"; return 1; }
+    cat "$outdir/camera-relay.service" 2>/dev/null
+}
+
+unit=$(gen_unit "/tmp/mesa_icd.json" "") || unit=""
+if [[ -z "$unit" ]]; then
+    bad "hybrid: unit generation failed"
+else
+    if grep -q '^Environment=__EGL_VENDOR_LIBRARY_FILENAMES=/tmp/mesa_icd.json$' <<< "$unit"; then
+        ok "hybrid: unit pins the EGL vendor"
+    else
+        bad "hybrid: unit is missing the EGL vendor pin"
+    fi
+    # The blocking half. Staying silent here is not the same as choosing gpu:
+    # silence inherits cpu from /etc/environment.d and the pin does nothing.
+    if grep -q '^Environment=LIBCAMERA_SOFTISP_MODE=gpu$' <<< "$unit"; then
+        ok "hybrid: unit states gpu, outranking any inherited cpu"
+    else
+        bad "hybrid: unit does not state LIBCAMERA_SOFTISP_MODE=gpu — pin would be inert"
+    fi
+fi
+
+unit=$(gen_unit "" "NVIDIA GeForce RTX 4070 Laptop GPU/PCIe/SSE2") || unit=""
+if [[ -z "$unit" ]]; then
+    bad "nvidia-only: unit generation failed"
+else
+    if grep -q '^Environment=LIBCAMERA_SOFTISP_MODE=cpu$' <<< "$unit"; then
+        ok "nvidia-only: falls back to CPU debayer"
+    else
+        bad "nvidia-only: expected LIBCAMERA_SOFTISP_MODE=cpu"
+    fi
+    if grep -q '__EGL_VENDOR_LIBRARY_FILENAMES' <<< "$unit"; then
+        bad "nvidia-only: unit pinned a vendor ICD it has no iGPU for"
+    else
+        ok "nvidia-only: no vendor pin"
+    fi
+fi
+
+# Mesa-only needs no override of either kind. /proc/driver/nvidia is real state
+# we cannot stub, so skip rather than report a bogus failure on an NVIDIA host.
+if [[ -d /proc/driver/nvidia ]]; then
+    skip "mesa-only case: /proc/driver/nvidia exists on this host"
+else
+    unit=$(gen_unit "" "Mesa Intel(R) Arc(tm) Graphics (MTL)") || unit=""
+    if [[ -z "$unit" ]]; then
+        bad "mesa-only: unit generation failed"
+    elif grep -q 'LIBCAMERA_SOFTISP_MODE\|__EGL_VENDOR_LIBRARY_FILENAMES' <<< "$unit"; then
+        bad "mesa-only: unit set a GPU override it does not need"
+    else
+        ok "mesa-only: no GPU overrides"
+    fi
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/webcam-fix-book5/README.md
+++ b/webcam-fix-book5/README.md
@@ -418,6 +418,35 @@ into a bug report. `gst-launch-1.0 ... autovideosink` showing a picture proves
 the camera works but says nothing about the loopback, which is the part
 browsers actually read. (issue #65)
 
+### LED on but black image, on RTX models
+
+The Book5 Pro ships in RTX dGPU configurations, and those run the same
+libcamera Software ISP as the Book4 Ultra — so they hit the same hybrid-GPU
+bug. The privacy LED lights, `camera-relay status` says `STREAMING`, and apps
+get a black picture, because GLVND loads `10_nvidia.json` ahead of
+`50_mesa.json` and the EGL debayer lands on NVIDIA's driver:
+
+```
+ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
+ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
+```
+
+It only shows up under systemd — `cam` from a terminal works, because a desktop
+session usually has EGL already resolved to Mesa.
+
+`camera-relay enable-persistent` detects the hybrid setup and pins the vendor
+ICD to the iGPU in `camera-relay.service`, and `camera-relay doctor` reports the
+whole picture under **GPU / EGL debayer**. On an install from before this
+landed, regenerate the unit:
+
+```bash
+camera-relay disable-persistent && camera-relay enable-persistent
+```
+
+Full write-up, including the manual drop-in and the PipeWire-path caveat:
+[../webcam-fix-libcamera/README.md](../webcam-fix-libcamera/README.md) →
+*"LED on but black image, on laptops with a dedicated GPU"*.
+
 ### `camera-relay start` says `libcamerasrc element not found` — but it's installed
 
 If the plugin package is already the newest version and

--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -689,13 +689,78 @@ EOF
 fi
 echo "  ✓ Created /etc/profile.d/libcamera-ipa.sh"
 
+# Book5 Pro ships in RTX dGPU configurations, so it runs the same hybrid-GPU
+# stack as the Book4 Ultra and hits the same EGL bug: GLVND loads the vendor ICDs
+# in /usr/share/glvnd/egl_vendor.d in filename order, NVIDIA's ships as
+# 10_nvidia.json ahead of Mesa's 50_mesa.json, and libcamera's Software ISP then
+# runs its EGL debayer on NVIDIA's proprietary driver, which it cannot use:
+#     ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
+#     ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
+# The sensor still powers up (privacy LED on, relay says STREAMING) but not one
+# frame reaches v4l2loopback, so apps show a black picture. Same failure the
+# LIBCAMERA_SOFTISP_MODE=cpu block below was written for (#15, #50, #70), but
+# pinning the iGPU fixes it without giving up the framerate (#66). It only bites
+# under systemd — a desktop session normally has EGL already resolved to Mesa,
+# so `cam` from a terminal works and the bug looks like it isn't there.
+#
+# camera-relay bakes the pin into its own service unit (see detect_egl_vendor_pin
+# in ../camera-relay/camera-relay); detect the same thing here so the state is
+# visible at install time. Deliberately NOT written to /etc/environment.d like
+# LIBCAMERA_SOFTISP_MODE below: __EGL_VENDOR_LIBRARY_FILENAMES steers *every* GL
+# client on the system, so setting it globally would take NVIDIA offload away
+# from games and everything else. It belongs on the camera units only.
+# Keep this block in sync with webcam-fix-libcamera/install.sh.
+HYBRID_EGL_VENDOR=""
+HYBRID_GPU=false
+_nv_node=false
+_mesa_node=false
+_render_nodes=0
+for _node in /dev/dri/renderD*; do
+    [[ -e "$_node" ]] || continue
+    _render_nodes=$((_render_nodes + 1))
+    _drv=""
+    _link=$(readlink -f "/sys/class/drm/$(basename "$_node")/device/driver" 2>/dev/null) || _link=""
+    [[ -n "$_link" ]] && _drv=$(basename "$_link")
+    case "$_drv" in
+        nvidia|nvidia-drm) _nv_node=true ;;
+        "")                ;;
+        *)                 _mesa_node=true ;;
+    esac
+done
+if $_nv_node && $_mesa_node && [[ "$_render_nodes" -ge 2 ]]; then
+    HYBRID_GPU=true
+    # Derive the vendor ICD from the iGPU that is actually present rather than
+    # hardcoding 50_mesa.json: every non-NVIDIA render node here (i915, xe,
+    # amdgpu, radeon) is driven by Mesa's EGL, so the file to pin is whichever
+    # ICD dispatches to libEGL_mesa — whatever the distro numbered it.
+    for _dir in /etc/glvnd/egl_vendor.d /usr/share/glvnd/egl_vendor.d; do
+        [[ -d "$_dir" ]] || continue
+        for _f in "$_dir"/*.json; do
+            [[ -f "$_f" ]] || continue
+            if grep -q 'libEGL_mesa' "$_f" 2>/dev/null; then
+                HYBRID_EGL_VENDOR="$_f"
+                break 2
+            fi
+        done
+    done
+fi
+if [[ -n "$HYBRID_EGL_VENDOR" ]]; then
+    echo "  ✓ Hybrid GPU (iGPU + NVIDIA) — camera-relay.service will pin EGL to"
+    echo "    $HYBRID_EGL_VENDOR (keeps the GPU debayer off the NVIDIA driver)"
+elif $HYBRID_GPU; then
+    echo "  ⚠ Hybrid GPU detected but no Mesa EGL vendor file found in"
+    echo "    /usr/share/glvnd/egl_vendor.d — if the camera LED lights but apps show"
+    echo "    black, run 'camera-relay doctor' and check the GPU / EGL section"
+fi
+unset _node _link _drv _dir _f _nv_node _mesa_node _render_nodes
+
 # If an NVIDIA GPU is present, libcamera's GPU (EGL) debayer is unreliable
 # (debayer_egl.cpp is incompatible with NVIDIA's proprietary EGL driver, and on
 # hybrid laptops EGL may pick the NVIDIA renderer even when the iGPU is active)
-# and produces black frames. camera-relay already forces CPU debayer on its own
-# service unit, but the PipeWire-libcamera path (used by apps that pick that
-# source directly) needs it too — so set it globally for all user services /
-# sessions. Book5 Pro ships in RTX dGPU configurations. (issues #15, #50, #70)
+# and produces black frames. camera-relay pins EGL to the iGPU and, failing that,
+# forces CPU debayer on its own service unit — but the PipeWire-libcamera path
+# (used by apps that pick that source directly) needs a fix too, and only the CPU
+# one is safe to set globally, so set that here. (issues #15, #50, #70)
 # Only force CPU debayer when NVIDIA is the *active EGL renderer* — merely having
 # an NVIDIA card present is not enough. On a hybrid laptop rendering on the Intel
 # iGPU, EGL never touches the NVIDIA driver, so GPU debayer works fine and forcing

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -365,6 +365,89 @@ disables and masks `v4l2-relayd.service` and moves the OEM
 re-run `sudo bash install.sh` and reboot. The change is fully reversible:
 `uninstall.sh` restores the OEM file and re-enables the service.
 
+### LED on but black image, on laptops with a dedicated GPU
+
+**Symptom.** The webcam privacy LED lights up, `camera-relay status` reports
+`STREAMING`, and apps still get a black picture — Google Meet says *"Your camera
+may be blocked"*. Affects every hybrid-GPU laptop (Intel or AMD iGPU + NVIDIA
+dGPU), which includes all Galaxy Book4 Ultra and the RTX variants of the Book5
+Pro.
+
+**Cause.** libcamera's Software ISP converts Bayer→RGB on the GPU through EGL.
+Which GPU that is comes from GLVND, which loads the vendor ICDs in
+`/usr/share/glvnd/egl_vendor.d` in filename order — and NVIDIA's ships as
+`10_nvidia.json`, ahead of Mesa's `50_mesa.json`. The debayer therefore runs on
+NVIDIA's proprietary EGL driver, which it is not compatible with:
+
+```
+ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
+ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
+```
+
+The sensor powers up — hence the LED — but every frame dies in the conversion
+and nothing ever reaches v4l2loopback.
+
+**Why it is so easy to misdiagnose.** Run `cam` from a terminal and it usually
+works: a desktop session normally has EGL already resolved to Mesa. The failure
+only appears inside the systemd user service, which inherits none of that.
+
+Confirm it directly:
+
+```bash
+__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json cam -c 1 -C5
+```
+
+That should report a Mesa renderer and ~30 fps. Swapping `50_mesa.json` for
+`10_nvidia.json` hangs and dies at the timeout without a single frame.
+
+**Fix.** Handled automatically — `camera-relay enable-persistent` detects the
+hybrid setup and bakes the pin into `camera-relay.service`:
+
+```
+Environment=__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json
+```
+
+If you are on an install from before this landed, re-run the installer, or just
+regenerate the unit:
+
+```bash
+camera-relay disable-persistent && camera-relay enable-persistent
+```
+
+`camera-relay doctor` now prints a **GPU / EGL debayer** section that lists the
+render nodes and their drivers, the vendor ICDs in GLVND's load order, the pin
+actually in effect, and any `debayerGPU failed` lines from the pipeline log.
+
+To apply it by hand instead — e.g. to a unit you maintain yourself — drop in:
+
+```bash
+mkdir -p ~/.config/systemd/user/camera-relay.service.d
+printf '[Service]\nEnvironment=__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json\n' \
+  > ~/.config/systemd/user/camera-relay.service.d/10-force-intel-gpu.conf
+systemctl --user daemon-reload && systemctl --user restart camera-relay.service
+```
+
+Do **not** put `__EGL_VENDOR_LIBRARY_FILENAMES` in `/etc/environment.d`: unlike
+`LIBCAMERA_SOFTISP_MODE` it steers every GL client on the machine, so a global
+setting would take NVIDIA offload away from games and everything else.
+
+**Known gap.** The pin covers the camera-relay path. Apps that read the camera
+through **PipeWire's libcamera source** directly (Chromium with
+`#enable-webrtc-pipewire-camera`) run the debayer inside `pipewire.service`,
+which has no pin, so they can still hit this. Workaround — same drop-in, on
+PipeWire:
+
+```bash
+mkdir -p ~/.config/systemd/user/pipewire.service.d
+printf '[Service]\nEnvironment=__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json\n' \
+  > ~/.config/systemd/user/pipewire.service.d/10-force-intel-gpu.conf
+systemctl --user daemon-reload && systemctl --user restart pipewire.service
+```
+
+The slower but unconditionally safe alternative for that path is CPU debayer
+(`LIBCAMERA_SOFTISP_MODE=cpu`), which the installer already sets globally when
+NVIDIA is the *active* renderer.
+
 ### Desaturated, green-tinted or purple image (colour tuning)
 
 The bundled `ov02c10.yaml` ships a conservative colour-correction matrix (CCM).

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1374,6 +1374,7 @@ fi
 # below: __EGL_VENDOR_LIBRARY_FILENAMES steers *every* GL client on the system,
 # so setting it globally would take NVIDIA offload away from games and everything
 # else. It belongs on the camera units only.
+# Keep this block in sync with webcam-fix-book5/install.sh.
 HYBRID_EGL_VENDOR=""
 HYBRID_GPU=false
 _nv_node=false

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1352,12 +1352,79 @@ if getent group kvm >/dev/null 2>&1; then
     fi
 fi
 
+# On a hybrid laptop — Intel/AMD iGPU + NVIDIA dGPU, which is every Galaxy Book4
+# Ultra — GLVND loads the EGL vendor ICDs in /usr/share/glvnd/egl_vendor.d in
+# filename order, and NVIDIA's ships as 10_nvidia.json, ahead of Mesa's
+# 50_mesa.json. libcamera's Software ISP then runs its EGL debayer on NVIDIA's
+# proprietary driver, which it is not compatible with:
+#     ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
+#     ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
+# The sensor still powers up (privacy LED on, relay says STREAMING) but not one
+# frame reaches v4l2loopback, so apps show a black picture. Same failure the
+# LIBCAMERA_SOFTISP_MODE=cpu block below was written for (#15, #50), but pinning
+# the iGPU fixes it without giving up the framerate (#66).
+#
+# This only bites under systemd: a desktop session normally has EGL already
+# resolved to Mesa, so running `cam` from a terminal works and the bug looks like
+# it isn't there. camera-relay bakes the pin into its own service unit (see
+# detect_egl_vendor_pin in ../camera-relay/camera-relay); detect the same thing
+# here so the state is visible at install time.
+#
+# Deliberately NOT written to /etc/environment.d like LIBCAMERA_SOFTISP_MODE
+# below: __EGL_VENDOR_LIBRARY_FILENAMES steers *every* GL client on the system,
+# so setting it globally would take NVIDIA offload away from games and everything
+# else. It belongs on the camera units only.
+HYBRID_EGL_VENDOR=""
+HYBRID_GPU=false
+_nv_node=false
+_mesa_node=false
+_render_nodes=0
+for _node in /dev/dri/renderD*; do
+    [[ -e "$_node" ]] || continue
+    _render_nodes=$((_render_nodes + 1))
+    _drv=""
+    _link=$(readlink -f "/sys/class/drm/$(basename "$_node")/device/driver" 2>/dev/null) || _link=""
+    [[ -n "$_link" ]] && _drv=$(basename "$_link")
+    case "$_drv" in
+        nvidia|nvidia-drm) _nv_node=true ;;
+        "")                ;;
+        *)                 _mesa_node=true ;;
+    esac
+done
+if $_nv_node && $_mesa_node && [[ "$_render_nodes" -ge 2 ]]; then
+    HYBRID_GPU=true
+    # Derive the vendor ICD from the iGPU that is actually present rather than
+    # hardcoding 50_mesa.json: every non-NVIDIA render node here (i915, xe,
+    # amdgpu, radeon) is driven by Mesa's EGL, so the file to pin is whichever
+    # ICD dispatches to libEGL_mesa — whatever the distro numbered it.
+    for _dir in /etc/glvnd/egl_vendor.d /usr/share/glvnd/egl_vendor.d; do
+        [[ -d "$_dir" ]] || continue
+        for _f in "$_dir"/*.json; do
+            [[ -f "$_f" ]] || continue
+            if grep -q 'libEGL_mesa' "$_f" 2>/dev/null; then
+                HYBRID_EGL_VENDOR="$_f"
+                break 2
+            fi
+        done
+    done
+fi
+if [[ -n "$HYBRID_EGL_VENDOR" ]]; then
+    echo "  ✓ Hybrid GPU (iGPU + NVIDIA) — camera-relay.service will pin EGL to"
+    echo "    $HYBRID_EGL_VENDOR (keeps the GPU debayer off the NVIDIA driver)"
+elif $HYBRID_GPU; then
+    echo "  ⚠ Hybrid GPU detected but no Mesa EGL vendor file found in"
+    echo "    /usr/share/glvnd/egl_vendor.d — if the camera LED lights but apps show"
+    echo "    black, run 'camera-relay doctor' and check the GPU / EGL section"
+fi
+unset _node _link _drv _dir _f _nv_node _mesa_node _render_nodes
+
 # If an NVIDIA GPU is present, libcamera's GPU (EGL) debayer is unreliable
 # (debayer_egl.cpp is incompatible with NVIDIA's proprietary EGL driver, and on
 # hybrid laptops EGL may pick the NVIDIA renderer even when the iGPU is active).
-# camera-relay already forces CPU debayer on its own service unit, but the
-# PipeWire-libcamera path (used by apps that pick that source directly) needs it
-# too — so set it globally for all user services / sessions. (issue #50)
+# camera-relay pins EGL to the iGPU and, failing that, forces CPU debayer on its
+# own service unit — but the PipeWire-libcamera path (used by apps that pick that
+# source directly) needs a fix too, and only the CPU one is safe to set globally,
+# so set that here for all user services / sessions. (issue #50)
 # Only force CPU debayer when NVIDIA is the *active EGL renderer* — merely having
 # an NVIDIA card present is not enough. On a hybrid laptop rendering on the Intel
 # iGPU, EGL never touches the NVIDIA driver, so GPU debayer works fine and forcing


### PR DESCRIPTION
## The bug

On a hybrid-GPU laptop — every Galaxy Book4 Ultra, and the RTX variants of the Book5 Pro — the webcam privacy LED lights up, `camera-relay status` reports `STREAMING`, and apps get a black picture ("Your camera may be blocked" in Google Meet).

libcamera's Software ISP debayers Bayer→RGB on the GPU through EGL. Which GPU that is comes from GLVND, which loads the vendor ICDs in `/usr/share/glvnd/egl_vendor.d` in filename order — and NVIDIA's ships as `10_nvidia.json`, ahead of Mesa's `50_mesa.json`. So the debayer runs on NVIDIA's proprietary EGL driver, which it is not compatible with:

```
ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
```

The sensor powers up — hence the LED — but every frame dies in the conversion and nothing reaches v4l2loopback.

**It only breaks under systemd.** A desktop session normally has EGL already resolved to Mesa, so running `cam` from a terminal works and the bug looks like it isn't there. That is what makes it so easy to misdiagnose.

## Evidence

Galaxy Book4 Ultra, Kubuntu 26.04, kernel 7.0.0-28, libcamera 0.7.2, Mesa 26.0.3, NVIDIA 595.84:

```
__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/50_mesa.json  cam -c 1 -C5
  -> GL_RENDERER: Mesa Intel(R) Arc(tm) Graphics (MTL), 30.08 fps, zero errors

__EGL_VENDOR_LIBRARY_FILENAMES=/usr/share/glvnd/egl_vendor.d/10_nvidia.json cam -c 1 -C5
  -> hangs, dies at the timeout, not one frame
```

## The fix

`camera-relay` pins `__EGL_VENDOR_LIBRARY_FILENAMES` to the iGPU's vendor ICD, in the generated service unit and in `setup_environment`.

Pinning is conditional. Only a genuinely mixed NVIDIA-proprietary + Mesa setup gets a pin — on a single-GPU box it is redundant, and on an NVIDIA-only box pointing at a Mesa ICD that cannot drive the hardware would break a working camera. The target is derived from the render nodes actually present, not hardcoded to `50_mesa.json`, since the number is only a load-order hint and distros renumber it.

| topology | result |
| --- | --- |
| i915 / xe / amdgpu only | no pin |
| nvidia only | no pin — falls through to the CPU-debayer guard |
| i915 + nvidia | pin |
| amdgpu + nvidia | pin |
| xe + nvidia-drm | pin |
| i915 + nouveau | no pin (both Mesa, no ordering problem) |

This supersedes the CPU-debayer fallback on hybrid machines, so the two are now **exclusive**. Setting both left `LIBCAMERA_SOFTISP_MODE=cpu` winning (it touches no EGL at all) and the pin dead in the unit on exactly the machines it was written for, at a large cost in framerate (#66). CPU debayer still covers the case with no iGPU to fall back to.

## `camera-relay doctor`

When the debayer fails, every other check stays green — libcamerasrc loads, refcount is non-zero, service is active, `status` says STREAMING. That green wall is what made this hard to place. New **GPU / EGL debayer** section:

```
── GPU / EGL debayer ──
  render node: /dev/dri/renderD128 (driver i915)
  render node: /dev/dri/renderD129 (driver nvidia)
  EGL vendor ICD: /usr/share/glvnd/egl_vendor.d/10_nvidia.json (libEGL_nvidia.so.0)
  EGL vendor ICD: /usr/share/glvnd/egl_vendor.d/50_mesa.json (libEGL_mesa.so.0)
  topology: HYBRID (NVIDIA dGPU + Mesa-driven iGPU)
  vendor pin (this shell):   none
  vendor pin (service unit): /usr/share/glvnd/egl_vendor.d/50_mesa.json
  pipeline EGL (from /run/user/1000/camera-relay.log):
    EGL_VENDOR: Mesa Project
    GL_RENDERER: Mesa Intel(R) Arc(tm) Graphics (MTL)
  debayer throughput: Debayer processed 30 frames in 141265us, 4708 us/frame
```

and on a broken machine:

```
  → HYBRID GPU WITH NO PIN. GLVND loads the NVIDIA ICD first, so the
    Software ISP's EGL debayer runs on NVIDIA's driver and fails.
  → GPU DEBAYER FAILED — this is why no picture reaches the loopback: …
```

`NO FRAMES` / `BLANK FRAMES` now name the GPU cause instead of leaving the reader to connect two sections thirty lines apart.

One fix worth calling out: doctor reads **both** relay logs. The pipeline lives in a different process per mode — always-on writes to `camera-relay-gst.log` via `start_pipeline()`, while on-demand (the default, and what `enable-persistent` sets up) runs `gst-launch` under `camera-relay-monitor` and everything lands in `camera-relay.log`. Reading only the first missed libcamera's EGL banner *and* the debayer failure in the mode nearly everyone runs.

## Installers

Both installers already force CPU debayer globally when NVIDIA is the active renderer (#15, #50, #70). That misses the hybrid case: the desktop renders on the iGPU, so `glxinfo` reports Intel and no fix is applied, yet the relay service still lands on `10_nvidia.json`. They now run the same detection and report it in the install log.

`__EGL_VENDOR_LIBRARY_FILENAMES` is deliberately **not** written to `/etc/environment.d` like `LIBCAMERA_SOFTISP_MODE` — it steers every GL client on the machine, so a global setting would take NVIDIA offload away from games and everything else. It belongs on the camera units only.

Both installers get the identical block, with a "keep in sync" comment, until #70's shared `lib/common.sh` exists.

## Known gap (documented, not fixed)

Apps reading the camera through **PipeWire's libcamera source** — Chromium with `#enable-webrtc-pipewire-camera`, which 6c205ba established is *required* on libcamera 0.7+ — run the debayer inside `pipewire.service`, which has no pin, so they can still hit this. The README gives the `pipewire.service.d` drop-in as a workaround. Not shipped: pinning EGL inside PipeWire for every user is a wider blast radius than this fix needs, and it deserves its own change.

## Testing

Verified on the Book4 Ultra above: unit regenerated with the pin, manual drop-in removed, `REAL PICTURE` with 128 distinct byte values, debayer confirmed on the Arc iGPU. Detection logic exercised across all six topologies in the table. Every commit is independently `bash -n` clean.

Not tested: a hybrid box with `prime-select nvidia`. That configuration previously got CPU debayer and now gets the pin — the behaviour change is intentional (it is what #66 asked for) but a second tester would be welcome.

Also not tested: an AMD iGPU + NVIDIA machine. The detection covers it, but no such Samsung model was available.

## Note on issue numbers

This bug has no filed issue; I did not invent a number for it. The references to #15/#50/#66/#70 are to the genuinely related work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
