### PR TITLE
docs: the 26 MHz OV02C10 clock is per-board, not Raptor Lake only

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ The internal DMIC requires SOF (Sound Open Firmware) with a recent enough firmwa
 
 ### [Webcam Fix — Book3 / Book4](webcam-fix-libcamera/) — IPU6 + libcamera (Recommended)
 
-The built-in webcam uses Intel IPU6 (Meteor Lake or Raptor Lake) with an OmniVision OV02C10 sensor. This fix uses the open-source libcamera Simple pipeline handler with Software ISP, accessed through PipeWire. Includes IVSC module loading, initramfs configuration (eliminating the boot race condition), sensor tuning, WirePlumber rules to hide raw IPU6 nodes, and an on-demand camera relay for non-PipeWire apps (Zoom, OBS, VLC). The installer also auto-detects the [26 MHz clock issue](ov02c10-26mhz-fix/) affecting some Raptor Lake models and offers to install the DKMS fix.
+The built-in webcam uses Intel IPU6 (Meteor Lake or Raptor Lake) with an OmniVision OV02C10 sensor. This fix uses the open-source libcamera Simple pipeline handler with Software ISP, accessed through PipeWire. Includes IVSC module loading, initramfs configuration (eliminating the boot race condition), sensor tuning, WirePlumber rules to hide raw IPU6 nodes, and an on-demand camera relay for non-PipeWire apps (Zoom, OBS, VLC). The installer also auto-detects the [26 MHz clock issue](ov02c10-26mhz-fix/) — which affects individual boards on both Raptor Lake and Meteor Lake, so it is detected from the dmesg error rather than from the platform — and offers to install the DKMS fix.
 
 - PipeWire-native apps (Firefox, Chromium) access the camera directly — no relay needed
 - Non-PipeWire apps use the on-demand V4L2 relay: near-zero CPU when idle, camera activates only when an app opens the device
@@ -175,6 +175,7 @@ The Galaxy Book4/5 laptops have built-in dual array digital microphones (DMIC). 
 
 - **Samsung Galaxy Book4 Ultra** — Ubuntu 24.04 LTS, kernel 6.17.0-14-generic (HWE)
 - **Samsung Galaxy Book4 Ultra** — Fedora 43, kernel 6.18.9 (community-confirmed)
+- **Samsung Galaxy Book4 Ultra (NP960XGL)** — Kubuntu 26.04, kernel 7.0.0-28-generic, speaker + webcam fix and camera relay confirmed under **Secure Boot** (all DKMS modules MOK-signed). Meteor Lake IPU6, but still needed the [26 MHz clock fix](ov02c10-26mhz-fix/). The internal mic worked without the [mic fix](mic-fix/) — kernel 7.0 already selects the SOF driver and exposes the DMIC
 - **Samsung Galaxy Book4 Pro** — Ubuntu 25.10, kernel 6.18.7, speaker fix confirmed (community-confirmed)
 - **Samsung Galaxy Book5 Pro** — Speaker fix confirmed working, mic continues to work (community-confirmed)
 - **Samsung Galaxy Book5 Pro (940XHA)** — Fedora 43, webcam fix confirmed (correct colors + orientation with bayer fix)

--- a/ov02c10-26mhz-fix/README.md
+++ b/ov02c10-26mhz-fix/README.md
@@ -1,7 +1,7 @@
 # OV02C10 26 MHz Clock Fix (DKMS)
 
-**Test fix** for Samsung Galaxy Book 3/4 models with **Raptor Lake IPU6** where the
-OV02C10 camera sensor fails to probe with:
+**Test fix** for Samsung Galaxy Book 3/4 models where the OV02C10 camera sensor
+fails to probe with:
 
 ```
 ov02c10 i2c-OVTI02C1:00: error -EINVAL: external clock 26000000 is not supported
@@ -10,20 +10,29 @@ ov02c10 i2c-OVTI02C1:00: error -EINVAL: external clock 26000000 is not supported
 ## What this fixes
 
 The upstream kernel's `ov02c10` driver only accepts a 19.2 MHz external clock.
-Raptor Lake IPU6 provides 26 MHz instead. This DKMS module patches the driver to
+Some IPU6 boards provide 26 MHz instead. This DKMS module patches the driver to
 accept both frequencies.
 
 Based on the patch from:
 https://lore.kernel.org/linux-media/CAKP_te-WT+HTEyhSvQ3snEOaTp5B1OUL18JjuzO238=_fTOuXQ@mail.gmail.com/
 
-Confirmed affected models include the Galaxy Book4 Pro **940XGK** (subsystem
-ID `0x144dca07`), in addition to the Book3/Book4 Ultra Raptor Lake variants.
+The 26 MHz clock is a **per-board property, not a platform property** — it shows
+up on both Raptor Lake and Meteor Lake IPU6. Confirmed affected models:
+
+- Galaxy Book4 Pro **940XGK** — Raptor Lake, subsystem ID `0x144dca07`
+- Galaxy Book4 Ultra **NP960XGL** — Meteor Lake IPU6 `8086:7d19`
+- Book3/Book4 Ultra Raptor Lake variants
+
+So don't decide by platform: check `dmesg` for the error above. That is exactly
+what `webcam-fix-libcamera/install.sh` does — it greps for the clock rejection
+and offers this fix, regardless of which IPU6 generation the board uses.
 
 ## Requirements
 
-- Linux kernel with in-tree `ov02c10` driver (kernel 6.8+, tested up to 6.17)
+- Linux kernel with in-tree `ov02c10` driver (kernel 6.8+, tested up to 7.0)
 - `dkms` and kernel headers (the install script will try to install these)
-- Samsung Galaxy Book with Raptor Lake IPU6 + OV02C10 sensor
+- Samsung Galaxy Book with IPU6 + OV02C10 sensor rejecting the 26 MHz clock
+  (Raptor Lake or Meteor Lake — confirm in `dmesg`, see above)
 
 ## Secure Boot
 

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -271,7 +271,7 @@ grep -i vsc /lib/modules/$(uname -r)/modules.builtin
 
 ### "external clock 26000000 is not supported" in dmesg
 
-Some Galaxy Book3/Book4 Ultra models (Raptor Lake) have a 26 MHz external clock instead of the expected 19.2 MHz. The installer detects this automatically and offers to install the [DKMS-patched ov02c10 driver](../ov02c10-26mhz-fix/). If you skipped the prompt during install, run the fix manually:
+Some Galaxy Book3/Book4 models have a 26 MHz external clock instead of the expected 19.2 MHz. This is a **per-board property, not a platform one** — it is confirmed on both Raptor Lake and Meteor Lake IPU6, including the Book4 Ultra `NP960XGL` (Meteor Lake, `8086:7d19`). Don't rule it out because your machine is Meteor Lake; go by the dmesg error. The installer detects it automatically and offers to install the [DKMS-patched ov02c10 driver](../ov02c10-26mhz-fix/). If you skipped the prompt during install, run the fix manually:
 
 ```bash
 cd ov02c10-26mhz-fix && sudo ./install.sh


### PR DESCRIPTION
The docs attribute the `external clock 26000000 is not supported` probe failure exclusively to Raptor Lake IPU6. It happens on Meteor Lake too.

## Evidence

Galaxy Book4 Ultra **NP960XGL-XG1BR**, IPU6 **Meteor Lake `8086:7d19`** (not Raptor Lake `8086:a75d`), Kubuntu 26.04 / kernel 7.0.0-28-generic. Before the fix:

```
ov02c10 i2c-OVTI02C1:00: error -EINVAL: external clock 26000000 is not supported
ov02c10 i2c-OVTI02C1:00: probe with driver ov02c10 failed with error -22
```

After installing `ov02c10-26mhz-fix`, the sensor probes and the message becomes informational:

```
ov02c10 i2c-OVTI02C1:00: 26000000Hz clock (not 19200000Hz): sensor runs fast;
advertising pixel_rate=216666666 and padding vts to 3152 for ~30fps
```

Camera confirmed working end to end afterwards — `cam -c 1 -C5` captures at 30.08 fps, and the camera relay serves non-PipeWire apps.

## Why the wording matters

As written, a Meteor Lake owner reads "Raptor Lake" and concludes the fix doesn't apply to them — when it is the one thing standing between them and a working camera. I nearly skipped it myself for exactly that reason.

**The installer was already correct.** `webcam-fix-libcamera/install.sh` greps dmesg for the clock rejection and never inspects the platform, so this PR only corrects the prose to match what the code already does. No code changes.

## Changes

- `ov02c10-26mhz-fix/README.md` — drop "Raptor Lake" from the scope; state the clock is a per-board property; list confirmed models per platform; point readers at `dmesg` instead of the platform name; bump tested kernel ceiling 6.17 -> 7.0
- `webcam-fix-libcamera/README.md` — same correction in the troubleshooting entry
- `README.md` — same correction in the webcam fix overview; add the Book4 Ultra / Kubuntu 26.04 / kernel 7.0.0-28 entry to "Tested On"

## Note on the "Tested On" entry

All four DKMS modules (`ov02c10`, `ipu-bridge-fix`, `v4l2loopback`, `max98390-hda`) build unmodified against kernel 7.0 and load MOK-signed under Secure Boot. The internal mic needed no `mic-fix` there — kernel 7.0 already selects the SOF driver and exposes the DMIC.