### PR TITLE
webcam-fix-libcamera: actually hide the raw MC-centric camera nodes

### DIFF
--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -24,6 +24,24 @@ SERVICE_DIR="${HOME}/.config/systemd/user"
 SERVICE_NAME="camera-relay.service"
 LOOPBACK_CONF="/etc/modprobe.d/99-camera-relay-loopback.conf"
 MONITOR_BIN="/usr/local/bin/camera-relay-monitor"
+LAUNCHER_BIN="/usr/local/bin/camera-relay-gst"
+
+# Arguments shared by every launcher invocation. The launcher is setgid, so it
+# replaces its environment wholesale rather than trusting what it inherited —
+# the paths setup_environment exported have to be handed over as arguments.
+LAUNCHER_ARGS=()
+build_launcher_args() {
+    LAUNCHER_ARGS=()
+    [[ -n "${GST_PLUGIN_PATH:-}" ]] && \
+        LAUNCHER_ARGS+=(--gst-plugin-path "$GST_PLUGIN_PATH")
+    [[ -n "${LIBCAMERA_IPA_MODULE_PATH:-}" ]] && \
+        LAUNCHER_ARGS+=(--ipa-path "$LIBCAMERA_IPA_MODULE_PATH")
+    [[ -n "${LIBCAMERA_SOFTISP_MODE:-}" ]] && \
+        LAUNCHER_ARGS+=(--softisp-mode "$LIBCAMERA_SOFTISP_MODE")
+    [[ -n "${RELAY_COLOR_FILTER:-}" ]] && \
+        LAUNCHER_ARGS+=(--color-filter "$RELAY_COLOR_FILTER")
+    return 0
+}
 
 # ── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -63,23 +81,29 @@ detect_camera_name() {
     # Output format: "1: 'ov02c10' (\_SB_.PC00.LNK0)"
     # Extract the camera ID from parentheses — this is what gst-launch needs
     # for the camera-name property (not the display name in quotes).
-    local cam_cmd=""
-    # Prefer /usr/local/bin/cam only if it actually runs (not broken by stale libs)
-    if [[ -x /usr/local/bin/cam ]] && /usr/local/bin/cam -l &>/dev/null; then
-        cam_cmd="/usr/local/bin/cam"
+    # The raw camera nodes belong to the memberless camera-relay group, so a
+    # plain `cam` run as the user can no longer enumerate them. Go through the
+    # launcher, which holds the group. Direct `cam` remains the fallback for
+    # installs without the launcher and for hardware whose nodes were never
+    # restricted (nothing MC-centric to hide).
+    local -a cam_cmd=()
+    if [[ -x "$LAUNCHER_BIN" ]] && "$LAUNCHER_BIN" --list-cameras &>/dev/null; then
+        cam_cmd=("$LAUNCHER_BIN" --list-cameras)
+    elif [[ -x /usr/local/bin/cam ]] && /usr/local/bin/cam -l &>/dev/null; then
+        cam_cmd=(/usr/local/bin/cam -l)
     elif command -v cam &>/dev/null; then
-        cam_cmd="cam"
+        cam_cmd=(cam -l)
     fi
-    if [[ -n "$cam_cmd" ]]; then
+    if (( ${#cam_cmd[@]} > 0 )); then
         local name
-        name=$("$cam_cmd" -l 2>/dev/null | grep -oP '\(([^)]+)\)' | head -1 | tr -d '()')
+        name=$("${cam_cmd[@]}" 2>/dev/null | grep -oP '\(([^)]+)\)' | head -1 | tr -d '()')
         if [[ -n "$name" ]]; then
             echo "$name" > "$CAMERA_CACHE"
             echo "$name"
             return 0
         fi
         # Fallback to quoted display name if no parenthesized ID
-        name=$("$cam_cmd" -l 2>/dev/null | grep -oP "'[^']+'" | head -1 | tr -d "'")
+        name=$("${cam_cmd[@]}" 2>/dev/null | grep -oP "'[^']+'" | head -1 | tr -d "'")
         if [[ -n "$name" ]]; then
             echo "$name" > "$CAMERA_CACHE"
             echo "$name"
@@ -558,30 +582,20 @@ start_pipeline() {
     local fast="${3:-false}"
     local gst_log="${XDG_RUNTIME_DIR:-/tmp}/camera-relay-gst.log"
 
-    # gst-launch-1.0 interprets backslashes as escape characters.
-    # Camera names like "\_SB_.LNK0" need double-escaping.
-    local gst_camera_name="${camera_name//\\/\\\\}"
-
-    # Use io-mode=mmap for v4l2sink — kernel-managed buffers are the most
-    # compatible across v4l2loopback versions. io-mode=rw (1) breaks on
-    # some Fedora systems; io-mode=auto (0) may fall through to rw.
-    # GStreamer enum: 0=auto, 1=rw, 2=mmap, 3=userptr, 4=dmabuf
-    # RELAY_COLOR_FILTER: optional GStreamer element(s) for color correction.
-    # Set in service environment to apply per-sensor tuning, e.g.:
+    # The launcher assembles the pipeline itself — it is setgid and must never
+    # run a command line handed to it. Backslash escaping for the gst-launch
+    # parser (camera names look like "\_SB_.LNK0") happens in there too.
+    # RELAY_COLOR_FILTER: optional GStreamer element(s) for color correction,
+    # set in the service environment for per-sensor tuning, e.g.
     #   RELAY_COLOR_FILTER="videobalance saturation=0.85"
-    local -a color_filter=()
-    if [[ -n "${RELAY_COLOR_FILTER:-}" ]]; then
-        color_filter=(! $RELAY_COLOR_FILTER)
-    fi
+    # The launcher accepts only allow-listed video filters.
+    build_launcher_args
 
     local -a gst_cmd=(
-        gst-launch-1.0 -e
-        libcamerasrc camera-name="$gst_camera_name"
-        ! queue max-size-buffers=3 leaky=downstream
-        ! videoconvert
-        "${color_filter[@]}"
-        ! "video/x-raw,format=YUY2"
-        ! v4l2sink device="$loopback_dev" io-mode=mmap sync=false
+        "$LAUNCHER_BIN"
+        --camera "$camera_name"
+        --v4l2-sink "$loopback_dev"
+        "${LAUNCHER_ARGS[@]}"
     )
 
     "${gst_cmd[@]}" >"$gst_log" 2>&1 &
@@ -666,13 +680,13 @@ cmd_start() {
         info "Starting relay (foreground)..."
         echo "streaming" > "$STATE_CACHE"
         echo $$ > "$PID_FILE"
-        local gst_camera_name="${camera_name//\\/\\\\}"
-        exec gst-launch-1.0 -e \
-            libcamerasrc camera-name="$gst_camera_name" \
-            ! queue max-size-buffers=3 leaky=downstream \
-            ! videoconvert \
-            ! "video/x-raw,format=YUY2" \
-            ! v4l2sink device="$loopback_dev" io-mode=mmap sync=false
+        # Same launcher as the backgrounded path, so this one now honours
+        # RELAY_COLOR_FILTER too — it used to silently drop it.
+        build_launcher_args
+        exec "$LAUNCHER_BIN" \
+            --camera "$camera_name" \
+            --v4l2-sink "$loopback_dev" \
+            "${LAUNCHER_ARGS[@]}"
     else
         info "Starting relay..."
         local pid
@@ -732,6 +746,13 @@ cmd_start_on_demand() {
 Run the installer to build it, or use 'camera-relay start' for always-on mode."
     fi
 
+    # Without the launcher the pipeline cannot open the raw camera nodes —
+    # they belong to the camera-relay group, which this session is not in.
+    if [[ ! -x "$LAUNCHER_BIN" ]]; then
+        die "camera-relay-gst not found at $LAUNCHER_BIN.
+Run the installer to build it — the pipeline needs it to reach the camera."
+    fi
+
     echo $$ > "$PID_FILE"
     echo "idle" > "$STATE_CACHE"
 
@@ -745,20 +766,14 @@ Run the installer to build it, or use 'camera-relay start' for always-on mode."
     # YUY2 frames from its stdout, and relays them to the device.
     # This avoids the writer fd handoff gap — the monitor always holds
     # the device open, so ready_for_capture never drops.
-    local gst_camera_name="${camera_name//\\/\\\\}"
-    local -a color_filter=()
-    if [[ -n "${RELAY_COLOR_FILTER:-}" ]]; then
-        color_filter=(! $RELAY_COLOR_FILTER)
-    fi
+    build_launcher_args
 
     local -a gst_cmd=(
-        gst-launch-1.0 -e
-        libcamerasrc camera-name="$gst_camera_name"
-        ! queue max-size-buffers=3 leaky=downstream
-        ! videoconvert
-        "${color_filter[@]}"
-        ! "video/x-raw,format=YUY2,width=1920,height=1080"
-        ! fdsink fd=3 sync=false
+        "$LAUNCHER_BIN"
+        --camera "$camera_name"
+        --fd-sink 3
+        --width 1920 --height 1080
+        "${LAUNCHER_ARGS[@]}"
     )
 
     # Clean up all children on exit
@@ -916,6 +931,45 @@ cmd_doctor() {
         echo "  Groups:  video group OK"
     else
         echo "  Groups:  NOT in the 'video' group — sudo usermod -aG video $USER, then log out and back in"
+    fi
+
+    # The raw camera nodes are reachable only through the setgid launcher. If
+    # it loses that bit (a plain `cp` drops it) the camera stops working, with
+    # nothing in the GStreamer log pointing at the cause.
+    if [[ -x "$LAUNCHER_BIN" ]]; then
+        local l_mode l_group
+        l_mode=$(stat -c%a "$LAUNCHER_BIN" 2>/dev/null || echo "")
+        l_group=$(stat -c%G "$LAUNCHER_BIN" 2>/dev/null || echo "?")
+        if [[ "$l_mode" == 2??? ]]; then
+            echo "  Launcher: setgid $l_group OK"
+        else
+            echo "  Launcher: $LAUNCHER_BIN is not setgid (mode ${l_mode:-?}) —"
+            echo "            it cannot reach the raw camera nodes. Re-run the installer."
+        fi
+    else
+        echo "  Launcher: $LAUNCHER_BIN missing — re-run the installer"
+    fi
+
+    # Self-check the whole point of the arrangement: any MC-centric node this
+    # session can still open is one that shows up as a bogus camera in app
+    # pickers. The helper can only report on nodes it manages to open, so a
+    # successful IO_MC=1 read here IS the leak.
+    local mc_helper=/usr/local/lib/udev/camera-relay-v4l2-io-mc
+    if [[ -x "$mc_helper" ]]; then
+        local leaked=0 v
+        for v in /dev/video*; do
+            [[ -e "$v" ]] || continue
+            if [[ "$("$mc_helper" "$v" 2>/dev/null)" == "ID_V4L_IO_MC=1" ]]; then
+                leaked=$((leaked + 1))
+            fi
+        done
+        if (( leaked > 0 )); then
+            echo "  MC nodes: $leaked raw node(s) still open to this session —"
+            echo "            they will appear as spurious cameras in apps."
+            echo "            Re-run the installer, then log out and back in."
+        else
+            echo "  MC nodes: hidden from this session OK"
+        fi
     fi
 
     echo

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -38,6 +38,11 @@ build_launcher_args() {
         LAUNCHER_ARGS+=(--ipa-path "$LIBCAMERA_IPA_MODULE_PATH")
     [[ -n "${LIBCAMERA_SOFTISP_MODE:-}" ]] && \
         LAUNCHER_ARGS+=(--softisp-mode "$LIBCAMERA_SOFTISP_MODE")
+    # Must be forwarded explicitly: without the pin the debayer lands on
+    # whichever EGL ICD GLVND loads first, which on a hybrid laptop is
+    # NVIDIA's — and every frame comes out black (PR #76).
+    [[ -n "${__EGL_VENDOR_LIBRARY_FILENAMES:-}" ]] && \
+        LAUNCHER_ARGS+=(--egl-vendor "$__EGL_VENDOR_LIBRARY_FILENAMES")
     [[ -n "${RELAY_COLOR_FILTER:-}" ]] && \
         LAUNCHER_ARGS+=(--color-filter "$RELAY_COLOR_FILTER")
     return 0

--- a/camera-relay/camera-relay-gst.c
+++ b/camera-relay/camera-relay-gst.c
@@ -1,0 +1,433 @@
+/*
+ * camera-relay-gst — setgid launcher for the libcamera pipeline
+ *
+ * The raw IPU6/IPU7 ISYS nodes are owned by the 'camera-relay' group so
+ * that ordinary applications cannot open them (see
+ * 90-camera-relay-mc-nodes.rules). libcamera still needs them, so the one
+ * process that legitimately drives the camera gets the group through this
+ * setgid launcher. The UID never changes: the pipeline stays inside the
+ * user's session, keeping the uaccess ACLs on the loopback and the media
+ * node, the EGL context used for GPU debayer, and the monitor's
+ * same-UID /proc scan all working.
+ *
+ * SECURITY — the two properties this file exists to hold:
+ *
+ *   1. It never executes a command line it was handed. Doing so would give
+ *      the caller the group back and defeat the whole arrangement. Every
+ *      input is validated and the pipeline is assembled here.
+ *
+ *   2. It builds a fresh environment instead of filtering the inherited
+ *      one. GStreamer and libcamera both load code from paths named by
+ *      environment variables (GST_PLUGIN_PATH, GST_REGISTRY,
+ *      LIBCAMERA_IPA_MODULE_PATH, ...); a deny-list would rot. Directory
+ *      arguments are accepted only under root-owned prefixes.
+ *
+ * setresgid() before exec is deliberate: with egid != rgid the loader
+ * marks the child AT_SECURE and glibc drops LD_LIBRARY_PATH. That is
+ * survivable here because ld.so.conf.d puts the patched libcamera ahead
+ * of the system one, but an AT_SECURE child also loses other inherited
+ * state for no benefit. Equalising the three GIDs keeps the child normal.
+ *
+ * Build:  gcc -O2 -Wall -o camera-relay-gst camera-relay-gst.c
+ * Usage:  camera-relay-gst --camera NAME --v4l2-sink /dev/video0
+ *         camera-relay-gst --camera NAME --fd-sink 3 --width 1920 --height 1080
+ *         camera-relay-gst --list-cameras
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+
+/* Shared writable state for the pipeline's own caches. Root-owned,
+ * group-writable, so a user cannot plant a poisoned GStreamer registry
+ * (the registry maps elements to .so paths that get dlopen()ed). */
+#define CACHE_DIR "/var/cache/camera-relay"
+
+#define MAX_ARGS 64
+
+/* Directory arguments must live under one of these. All root-owned, so a
+ * validated path cannot point at anything the caller controls. */
+static const char *const TRUSTED_PREFIXES[] = {
+	"/usr/lib/", "/usr/lib64/", "/usr/share/",
+	"/usr/local/lib/", "/usr/local/lib64/", "/usr/local/share/",
+	NULL
+};
+
+/* Pure video filters. Excluding sources and sinks is what keeps a color
+ * filter from turning into file or network access. */
+static const char *const FILTER_ELEMENTS[] = {
+	"videobalance", "videoflip", "videoconvert", "videoscale",
+	"gamma", "coloreffects", "videomedian", "aspectratiocrop",
+	NULL
+};
+
+static const char *const GST_LAUNCH_PATHS[] = {
+	"/usr/bin/gst-launch-1.0", "/usr/local/bin/gst-launch-1.0", NULL
+};
+
+static const char *const CAM_PATHS[] = {
+	"/usr/local/bin/cam", "/usr/bin/cam", NULL
+};
+
+static void die(const char *fmt, ...)
+{
+	va_list ap;
+
+	va_start(ap, fmt);
+	fprintf(stderr, "camera-relay-gst: ");
+	vfprintf(stderr, fmt, ap);
+	fprintf(stderr, "\n");
+	va_end(ap);
+	exit(1);
+}
+
+static int in_list(const char *needle, const char *const *list)
+{
+	for (; *list; list++)
+		if (!strcmp(needle, *list))
+			return 1;
+	return 0;
+}
+
+static const char *first_existing(const char *const *paths)
+{
+	for (; *paths; paths++)
+		if (!access(*paths, X_OK))
+			return *paths;
+	return NULL;
+}
+
+/* Every accepted character must be one we are willing to hand to the
+ * gst-launch parser. Backslash is needed for ACPI names like
+ * \_SB_.PC00.LNK0; '!' and whitespace are what a pipeline injection would
+ * need, so they are absent by construction. */
+static int valid_camera_name(const char *s)
+{
+	if (!*s || strlen(s) > 128)
+		return 0;
+	for (; *s; s++) {
+		if (*s >= 'A' && *s <= 'Z') continue;
+		if (*s >= 'a' && *s <= 'z') continue;
+		if (*s >= '0' && *s <= '9') continue;
+		if (strchr("._-:\\/", *s)) continue;
+		return 0;
+	}
+	return 1;
+}
+
+static int valid_ident(const char *s, const char *extra)
+{
+	if (!*s)
+		return 0;
+	for (; *s; s++) {
+		if (*s >= 'A' && *s <= 'Z') continue;
+		if (*s >= 'a' && *s <= 'z') continue;
+		if (*s >= '0' && *s <= '9') continue;
+		if (strchr(extra, *s)) continue;
+		return 0;
+	}
+	return 1;
+}
+
+static void require_trusted_dir(const char *opt, const char *path)
+{
+	const char *const *p;
+	size_t len;
+
+	if (path[0] != '/')
+		die("%s must be an absolute path", opt);
+	if (strstr(path, ".."))
+		die("%s must not contain '..'", opt);
+
+	for (p = TRUSTED_PREFIXES; *p; p++) {
+		len = strlen(*p);
+		/* Match the prefix with or without its trailing slash, so
+		 * "/usr/local/lib" itself is accepted. */
+		if (!strncmp(path, *p, len) ||
+		    (!strncmp(path, *p, len - 1) && path[len - 1] == '\0'))
+			return;
+	}
+	die("%s must be under a root-owned system directory, got '%s'", opt, path);
+}
+
+/* gst-launch joins its argv and re-parses the result, so a backslash in
+ * the camera name is an escape unless doubled. */
+static char *escape_backslashes(const char *s)
+{
+	char *out, *o;
+
+	out = malloc(strlen(s) * 2 + 1);
+	if (!out)
+		die("out of memory");
+	for (o = out; *s; s++) {
+		if (*s == '\\')
+			*o++ = '\\';
+		*o++ = *s;
+	}
+	*o = '\0';
+	return out;
+}
+
+/*
+ * Append a RELAY_COLOR_FILTER spec, e.g. "videobalance saturation=0.85",
+ * optionally chained with '!'. Each stage must name an allow-listed filter
+ * and carry only simple name=value properties.
+ */
+static int append_color_filter(char **argv, int argc, char *spec)
+{
+	int expect_element = 1;
+	char *tok, *save;
+
+	for (tok = strtok_r(spec, " \t", &save); tok;
+	     tok = strtok_r(NULL, " \t", &save)) {
+		if (argc >= MAX_ARGS - 8)
+			die("color filter too long");
+
+		if (!strcmp(tok, "!")) {
+			if (expect_element)
+				die("color filter has an empty stage");
+			expect_element = 1;
+			argv[argc++] = tok;
+			continue;
+		}
+
+		if (expect_element) {
+			if (!in_list(tok, FILTER_ELEMENTS))
+				die("color filter element '%s' is not allowed", tok);
+			argv[argc++] = "!";
+			argv[argc++] = tok;
+			expect_element = 0;
+			continue;
+		}
+
+		/* property: name=value */
+		char *eq = strchr(tok, '=');
+		if (!eq || eq == tok)
+			die("color filter expects name=value, got '%s'", tok);
+		*eq = '\0';
+		if (!valid_ident(tok, "-_") || !valid_ident(eq + 1, "._-"))
+			die("color filter property '%s' is not allowed", tok);
+		*eq = '=';
+		argv[argc++] = tok;
+	}
+
+	if (expect_element)
+		die("color filter ends with a dangling '!'");
+	return argc;
+}
+
+/*
+ * Replace the inherited environment wholesale. Only entries built here
+ * survive, so nothing the caller set can steer code loading.
+ */
+static char **build_environment(const char *gst_plugin_path,
+				const char *ipa_path,
+				const char *softisp_mode)
+{
+	static char *env[10];
+	static char buf[5][PATH_MAX + 64];
+	int n = 0, b = 0;
+
+	env[n++] = "PATH=/usr/local/bin:/usr/bin:/bin";
+	/* Mesa and GStreamer both want somewhere to cache; point them at the
+	 * group-writable directory rather than the user's HOME. */
+	env[n++] = "HOME=" CACHE_DIR;
+	env[n++] = "GST_REGISTRY=" CACHE_DIR "/gst-registry.bin";
+	env[n++] = "MESA_SHADER_CACHE_DIR=" CACHE_DIR "/mesa";
+
+	if (gst_plugin_path) {
+		snprintf(buf[b], sizeof(buf[b]), "GST_PLUGIN_PATH=%s", gst_plugin_path);
+		env[n++] = buf[b++];
+	}
+	if (ipa_path) {
+		snprintf(buf[b], sizeof(buf[b]), "LIBCAMERA_IPA_MODULE_PATH=%s", ipa_path);
+		env[n++] = buf[b++];
+	}
+	if (softisp_mode) {
+		snprintf(buf[b], sizeof(buf[b]), "LIBCAMERA_SOFTISP_MODE=%s", softisp_mode);
+		env[n++] = buf[b++];
+	}
+
+	env[n] = NULL;
+	return env;
+}
+
+/*
+ * Take the group for real. Leaving egid != rgid would make the child
+ * AT_SECURE; it also leaves a saved-set GID around for no reason.
+ */
+static void assume_group(void)
+{
+	gid_t egid = getegid();
+
+	if (egid == getgid())
+		/* Not actually setgid — either an uninstalled build or a
+		 * system where the caller already holds the group. Let the
+		 * pipeline run and fail on its own if access is missing. */
+		return;
+
+	if (setresgid(egid, egid, egid) < 0)
+		die("setresgid: %s", strerror(errno));
+}
+
+static void usage(void)
+{
+	fprintf(stderr,
+		"usage: camera-relay-gst --camera NAME (--v4l2-sink DEV | --fd-sink N)\n"
+		"                        [--width W --height H] [--color-filter SPEC]\n"
+		"                        [--gst-plugin-path DIR] [--ipa-path DIR]\n"
+		"                        [--softisp-mode cpu|gpu]\n"
+		"       camera-relay-gst --list-cameras\n");
+	exit(1);
+}
+
+int main(int argc, char *argv[])
+{
+	const char *camera = NULL, *v4l2_sink = NULL, *gst_plugin_path = NULL;
+	const char *ipa_path = NULL, *softisp_mode = NULL;
+	char *color_filter = NULL;
+	long fd_sink = -1, width = 0, height = 0;
+	int list_cameras = 0;
+	char *gst_argv[MAX_ARGS];
+	char caps[128], camera_arg[300], sink_arg[64];
+	int n = 0, i;
+
+	for (i = 1; i < argc; i++) {
+		const char *a = argv[i];
+		const char *val = NULL;
+
+		/* Options that take a value */
+		if (i + 1 < argc)
+			val = argv[i + 1];
+
+		if (!strcmp(a, "--list-cameras")) {
+			list_cameras = 1;
+		} else if (!strcmp(a, "--camera") && val) {
+			camera = val; i++;
+		} else if (!strcmp(a, "--v4l2-sink") && val) {
+			v4l2_sink = val; i++;
+		} else if (!strcmp(a, "--fd-sink") && val) {
+			fd_sink = strtol(val, NULL, 10); i++;
+		} else if (!strcmp(a, "--width") && val) {
+			width = strtol(val, NULL, 10); i++;
+		} else if (!strcmp(a, "--height") && val) {
+			height = strtol(val, NULL, 10); i++;
+		} else if (!strcmp(a, "--color-filter") && val) {
+			color_filter = argv[++i];
+		} else if (!strcmp(a, "--gst-plugin-path") && val) {
+			gst_plugin_path = val; i++;
+		} else if (!strcmp(a, "--ipa-path") && val) {
+			ipa_path = val; i++;
+		} else if (!strcmp(a, "--softisp-mode") && val) {
+			softisp_mode = val; i++;
+		} else {
+			usage();
+		}
+	}
+
+	assume_group();
+
+	if (list_cameras) {
+		const char *cam = first_existing(CAM_PATHS);
+		char *cam_argv[] = { NULL, "-l", NULL };
+
+		if (camera || v4l2_sink || fd_sink >= 0)
+			die("--list-cameras takes no other options");
+		if (!cam)
+			die("cam not found; install libcamera tools");
+
+		cam_argv[0] = (char *)cam;
+		execve(cam, cam_argv, build_environment(gst_plugin_path, ipa_path,
+						        softisp_mode));
+		die("execve %s: %s", cam, strerror(errno));
+	}
+
+	/* ── validate ─────────────────────────────────────────────────── */
+
+	if (!camera)
+		usage();
+	if (!valid_camera_name(camera))
+		die("camera name contains characters that are not allowed");
+
+	if ((v4l2_sink != NULL) == (fd_sink >= 0))
+		die("give exactly one of --v4l2-sink or --fd-sink");
+
+	if (v4l2_sink) {
+		if (strncmp(v4l2_sink, "/dev/video", 10) ||
+		    !valid_ident(v4l2_sink + 10, ""))
+			die("--v4l2-sink must be /dev/videoN, got '%s'", v4l2_sink);
+	} else {
+		if (fd_sink < 3 || fd_sink > 20)
+			die("--fd-sink must be between 3 and 20");
+		if (fcntl(fd_sink, F_GETFD) < 0)
+			die("--fd-sink %ld is not open", fd_sink);
+	}
+
+	if ((width != 0) != (height != 0))
+		die("--width and --height must be given together");
+	if (width && (width < 16 || width > 8192 || height < 16 || height > 8192))
+		die("--width/--height out of range");
+
+	if (softisp_mode && strcmp(softisp_mode, "cpu") && strcmp(softisp_mode, "gpu"))
+		die("--softisp-mode must be 'cpu' or 'gpu'");
+	if (gst_plugin_path)
+		require_trusted_dir("--gst-plugin-path", gst_plugin_path);
+	if (ipa_path)
+		require_trusted_dir("--ipa-path", ipa_path);
+
+	/* ── assemble the pipeline ────────────────────────────────────── */
+
+	const char *gst = first_existing(GST_LAUNCH_PATHS);
+	if (!gst)
+		die("gst-launch-1.0 not found; install gstreamer1.0-tools");
+
+	char *escaped = escape_backslashes(camera);
+	snprintf(camera_arg, sizeof(camera_arg), "camera-name=%s", escaped);
+
+	gst_argv[n++] = (char *)gst;
+	gst_argv[n++] = "-e";
+	gst_argv[n++] = "libcamerasrc";
+	gst_argv[n++] = camera_arg;
+	gst_argv[n++] = "!";
+	gst_argv[n++] = "queue";
+	gst_argv[n++] = "max-size-buffers=3";
+	gst_argv[n++] = "leaky=downstream";
+	gst_argv[n++] = "!";
+	gst_argv[n++] = "videoconvert";
+
+	if (color_filter && *color_filter)
+		n = append_color_filter(gst_argv, n, color_filter);
+
+	if (width)
+		snprintf(caps, sizeof(caps),
+			 "video/x-raw,format=YUY2,width=%ld,height=%ld", width, height);
+	else
+		snprintf(caps, sizeof(caps), "video/x-raw,format=YUY2");
+	gst_argv[n++] = "!";
+	gst_argv[n++] = caps;
+
+	gst_argv[n++] = "!";
+	if (v4l2_sink) {
+		snprintf(sink_arg, sizeof(sink_arg), "device=%s", v4l2_sink);
+		gst_argv[n++] = "v4l2sink";
+		gst_argv[n++] = sink_arg;
+		gst_argv[n++] = "io-mode=mmap";
+	} else {
+		snprintf(sink_arg, sizeof(sink_arg), "fd=%ld", fd_sink);
+		gst_argv[n++] = "fdsink";
+		gst_argv[n++] = sink_arg;
+	}
+	gst_argv[n++] = "sync=false";
+	gst_argv[n] = NULL;
+
+	execve(gst, gst_argv,
+	       build_environment(gst_plugin_path, ipa_path, softisp_mode));
+	die("execve %s: %s", gst, strerror(errno));
+	return 1;
+}

--- a/camera-relay/camera-relay-gst.c
+++ b/camera-relay/camera-relay-gst.c
@@ -3,7 +3,7 @@
  *
  * The raw IPU6/IPU7 ISYS nodes are owned by the 'camera-relay' group so
  * that ordinary applications cannot open them (see
- * 90-camera-relay-mc-nodes.rules). libcamera still needs them, so the one
+ * 74-camera-relay-mc-nodes.rules). libcamera still needs them, so the one
  * process that legitimately drives the camera gets the group through this
  * setgid launcher. The UID never changes: the pipeline stays inside the
  * user's session, keeping the uaccess ACLs on the loopback and the media
@@ -50,6 +50,21 @@
 #define CACHE_DIR "/var/cache/camera-relay"
 
 #define MAX_ARGS 64
+
+/*
+ * Slots append_color_filter() must leave free. The longest tail emitted after
+ * it is the --v4l2-sink path:
+ *
+ *   "!"  caps  "!"  v4l2sink  device=…  io-mode=mmap  sync=false   → 7
+ *   NULL terminator                                                → 8
+ *
+ * and one iteration of that loop can append two entries at once ("!" plus the
+ * element name), so it has to stop while there is still room for both → 9.
+ *
+ * Keep this in step with the tail in main(): the --fd-sink path is one shorter,
+ * which is exactly what hid an off-by-one here until it was caught under ASan.
+ */
+#define TAIL_SLOTS 9
 
 /* Directory arguments must live under one of these. All root-owned, so a
  * validated path cannot point at anything the caller controls. */
@@ -222,7 +237,7 @@ static int append_color_filter(char **argv, int argc, char *spec)
 
 	for (tok = strtok_r(spec, " \t", &save); tok;
 	     tok = strtok_r(NULL, " \t", &save)) {
-		if (argc >= MAX_ARGS - 8)
+		if (argc >= MAX_ARGS - TAIL_SLOTS)
 			die("color filter too long");
 
 		if (!strcmp(tok, "!")) {
@@ -415,8 +430,13 @@ int main(int argc, char *argv[])
 		die("give exactly one of --v4l2-sink or --fd-sink");
 
 	if (v4l2_sink) {
+		/* The length bound is what the charset check leaves unsaid:
+		 * without it "/dev/video" plus a hundred digits validates and
+		 * then silently truncates into sink_arg. snprintf keeps that
+		 * safe, but saying the bound is better than relying on it. */
 		if (strncmp(v4l2_sink, "/dev/video", 10) ||
-		    !valid_ident(v4l2_sink + 10, ""))
+		    !valid_ident(v4l2_sink + 10, "") ||
+		    strlen(v4l2_sink + 10) > 3)
 			die("--v4l2-sink must be /dev/videoN, got '%s'", v4l2_sink);
 	} else {
 		if (fd_sink < 3 || fd_sink > 20)

--- a/camera-relay/camera-relay-gst.c
+++ b/camera-relay/camera-relay-gst.c
@@ -59,6 +59,13 @@ static const char *const TRUSTED_PREFIXES[] = {
 	NULL
 };
 
+/* Where GLVND keeps EGL vendor ICDs. Narrower than TRUSTED_PREFIXES because
+ * this value selects which driver the debayer runs on. */
+static const char *const EGL_VENDOR_PREFIXES[] = {
+	"/etc/glvnd/egl_vendor.d/", "/usr/share/glvnd/egl_vendor.d/",
+	NULL
+};
+
 /* Pure video filters. Excluding sources and sinks is what keeps a color
  * filter from turning into file or network access. */
 static const char *const FILTER_ELEMENTS[] = {
@@ -135,7 +142,8 @@ static int valid_ident(const char *s, const char *extra)
 	return 1;
 }
 
-static void require_trusted_dir(const char *opt, const char *path)
+static void require_prefix(const char *opt, const char *path,
+			   const char *const *prefixes)
 {
 	const char *const *p;
 	size_t len;
@@ -145,7 +153,7 @@ static void require_trusted_dir(const char *opt, const char *path)
 	if (strstr(path, ".."))
 		die("%s must not contain '..'", opt);
 
-	for (p = TRUSTED_PREFIXES; *p; p++) {
+	for (p = prefixes; *p; p++) {
 		len = strlen(*p);
 		/* Match the prefix with or without its trailing slash, so
 		 * "/usr/local/lib" itself is accepted. */
@@ -154,6 +162,34 @@ static void require_trusted_dir(const char *opt, const char *path)
 			return;
 	}
 	die("%s must be under a root-owned system directory, got '%s'", opt, path);
+}
+
+static void require_trusted_dir(const char *opt, const char *path)
+{
+	require_prefix(opt, path, TRUSTED_PREFIXES);
+}
+
+/*
+ * The EGL vendor pin is a colon-separated list of ICD files; validate each
+ * element. Without it the debayer lands on whichever ICD GLVND happens to load
+ * first, which on a hybrid laptop is NVIDIA's — and libcamera's EGL debayer
+ * fails against it, so every frame comes out black.
+ */
+static void require_egl_vendor_list(const char *opt, const char *list)
+{
+	char *copy, *tok, *save;
+
+	if (!*list)
+		die("%s must not be empty", opt);
+	copy = strdup(list);
+	if (!copy)
+		die("out of memory");
+
+	for (tok = strtok_r(copy, ":", &save); tok;
+	     tok = strtok_r(NULL, ":", &save))
+		require_prefix(opt, tok, EGL_VENDOR_PREFIXES);
+
+	free(copy);
 }
 
 /* gst-launch joins its argv and re-parses the result, so a backslash in
@@ -228,10 +264,11 @@ static int append_color_filter(char **argv, int argc, char *spec)
  */
 static char **build_environment(const char *gst_plugin_path,
 				const char *ipa_path,
-				const char *softisp_mode)
+				const char *softisp_mode,
+				const char *egl_vendor)
 {
-	static char *env[10];
-	static char buf[5][PATH_MAX + 64];
+	static char *env[12];
+	static char buf[6][PATH_MAX + 64];
 	int n = 0, b = 0;
 
 	env[n++] = "PATH=/usr/local/bin:/usr/bin:/bin";
@@ -251,6 +288,11 @@ static char **build_environment(const char *gst_plugin_path,
 	}
 	if (softisp_mode) {
 		snprintf(buf[b], sizeof(buf[b]), "LIBCAMERA_SOFTISP_MODE=%s", softisp_mode);
+		env[n++] = buf[b++];
+	}
+	if (egl_vendor) {
+		snprintf(buf[b], sizeof(buf[b]),
+			 "__EGL_VENDOR_LIBRARY_FILENAMES=%s", egl_vendor);
 		env[n++] = buf[b++];
 	}
 
@@ -282,7 +324,7 @@ static void usage(void)
 		"usage: camera-relay-gst --camera NAME (--v4l2-sink DEV | --fd-sink N)\n"
 		"                        [--width W --height H] [--color-filter SPEC]\n"
 		"                        [--gst-plugin-path DIR] [--ipa-path DIR]\n"
-		"                        [--softisp-mode cpu|gpu]\n"
+		"                        [--softisp-mode cpu|gpu] [--egl-vendor ICD[:ICD...]]\n"
 		"       camera-relay-gst --list-cameras\n");
 	exit(1);
 }
@@ -290,7 +332,7 @@ static void usage(void)
 int main(int argc, char *argv[])
 {
 	const char *camera = NULL, *v4l2_sink = NULL, *gst_plugin_path = NULL;
-	const char *ipa_path = NULL, *softisp_mode = NULL;
+	const char *ipa_path = NULL, *softisp_mode = NULL, *egl_vendor = NULL;
 	char *color_filter = NULL;
 	long fd_sink = -1, width = 0, height = 0;
 	int list_cameras = 0;
@@ -326,10 +368,24 @@ int main(int argc, char *argv[])
 			ipa_path = val; i++;
 		} else if (!strcmp(a, "--softisp-mode") && val) {
 			softisp_mode = val; i++;
+		} else if (!strcmp(a, "--egl-vendor") && val) {
+			egl_vendor = val; i++;
 		} else {
 			usage();
 		}
 	}
+
+	/* Validate everything that reaches the child environment before either
+	 * branch uses it — these select which code the pipeline loads, and
+	 * --list-cameras passes them through just the same. */
+	if (softisp_mode && strcmp(softisp_mode, "cpu") && strcmp(softisp_mode, "gpu"))
+		die("--softisp-mode must be 'cpu' or 'gpu'");
+	if (gst_plugin_path)
+		require_trusted_dir("--gst-plugin-path", gst_plugin_path);
+	if (ipa_path)
+		require_trusted_dir("--ipa-path", ipa_path);
+	if (egl_vendor)
+		require_egl_vendor_list("--egl-vendor", egl_vendor);
 
 	assume_group();
 
@@ -344,7 +400,7 @@ int main(int argc, char *argv[])
 
 		cam_argv[0] = (char *)cam;
 		execve(cam, cam_argv, build_environment(gst_plugin_path, ipa_path,
-						        softisp_mode));
+						        softisp_mode, egl_vendor));
 		die("execve %s: %s", cam, strerror(errno));
 	}
 
@@ -373,13 +429,6 @@ int main(int argc, char *argv[])
 		die("--width and --height must be given together");
 	if (width && (width < 16 || width > 8192 || height < 16 || height > 8192))
 		die("--width/--height out of range");
-
-	if (softisp_mode && strcmp(softisp_mode, "cpu") && strcmp(softisp_mode, "gpu"))
-		die("--softisp-mode must be 'cpu' or 'gpu'");
-	if (gst_plugin_path)
-		require_trusted_dir("--gst-plugin-path", gst_plugin_path);
-	if (ipa_path)
-		require_trusted_dir("--ipa-path", ipa_path);
 
 	/* ── assemble the pipeline ────────────────────────────────────── */
 
@@ -427,7 +476,7 @@ int main(int argc, char *argv[])
 	gst_argv[n] = NULL;
 
 	execve(gst, gst_argv,
-	       build_environment(gst_plugin_path, ipa_path, softisp_mode));
+	       build_environment(gst_plugin_path, ipa_path, softisp_mode, egl_vendor));
 	die("execve %s: %s", gst, strerror(errno));
 	return 1;
 }

--- a/camera-relay/tests/test-launcher-validation.sh
+++ b/camera-relay/tests/test-launcher-validation.sh
@@ -41,12 +41,27 @@ if ! gcc -O2 -Wall -Werror -o "$TMP/launcher" "$SRC" 2>"$TMP/build.log"; then
 fi
 ok "builds clean with -Wall -Werror"
 
+# For a setgid binary, memory safety is the property that matters most, and
+# input-rejection tests do not exercise it — an off-by-one in the argv guard
+# survived a green suite until it was found under ASan. Everything below runs
+# against the sanitized build when the toolchain has it.
+SAN="$TMP/launcher"
+if gcc -g -O1 -fsanitize=address,undefined -o "$TMP/launcher-san" "$SRC" 2>/dev/null; then
+    SAN="$TMP/launcher-san"
+    # The launcher leaks its escaped camera name on purpose: it is about to
+    # execve. That is not the kind of finding this suite is looking for.
+    export ASAN_OPTIONS=detect_leaks=0
+    ok "builds clean with -fsanitize=address,undefined"
+else
+    echo "  – note: no sanitizer support in this toolchain, running unsanitized"
+fi
+
 # fd 3 is opened for every run so the --fd-sink liveness check is not what
 # rejects these; each case must fail for the reason under test.
 reject() {
     local desc="$1"; shift
     local out
-    out=$("$TMP/launcher" "$@" 3>/dev/null 2>&1)
+    out=$("$SAN" "$@" 3>/dev/null 2>&1)
     if [[ $? -eq 0 ]]; then
         bad "$desc — accepted"
     elif [[ "$out" == *"is not open"* ]]; then
@@ -94,14 +109,14 @@ echo "── path options are validated on the --list-cameras path too ──"
 # This branch also exports them into the child environment; skipping validation
 # there would hand the group away just as effectively.
 for opt in --ipa-path --gst-plugin-path; do
-    out=$("$TMP/launcher" --list-cameras "$opt" /tmp/evil 2>&1)
+    out=$("$SAN" --list-cameras "$opt" /tmp/evil 2>&1)
     if [[ $? -ne 0 && "$out" == *"root-owned"* ]]; then
         ok "--list-cameras $opt /tmp/evil"
     else
         bad "--list-cameras $opt /tmp/evil — not validated"
     fi
 done
-out=$("$TMP/launcher" --list-cameras --egl-vendor /tmp/evil.json 2>&1)
+out=$("$SAN" --list-cameras --egl-vendor /tmp/evil.json 2>&1)
 if [[ $? -ne 0 && "$out" == *"root-owned"* ]]; then
     ok "--list-cameras --egl-vendor /tmp/evil.json"
 else
@@ -116,10 +131,37 @@ reject "sink outside /dev/video" --camera X --v4l2-sink /dev/../etc/passwd
 reject "--list-cameras mixed with a pipeline" --camera X --fd-sink 3 --list-cameras
 
 echo
+echo "── argv buffer holds at the guard boundary ──"
+# The color filter is the only caller-controlled input that grows the argv
+# array, so its guard is what stands between argv and a stack overflow. Sweep
+# across the boundary on BOTH sink paths: --v4l2-sink emits one more element
+# than --fd-sink, and testing only the shorter one is what let an off-by-one
+# through. Every length must land in exactly one of two states — accepted, or
+# refused by the guard. A sanitizer report is neither.
+sweep_ok=1
+for sink in "--v4l2-sink /dev/video9" "--fd-sink 3"; do
+    for k in $(seq 1 24); do
+        filter="videoconvert"
+        for ((i = 1; i < k; i++)); do filter="$filter ! videoconvert"; done
+        out=$("$SAN" --camera testcam $sink --color-filter "$filter" 3>/dev/null 2>&1)
+        if [[ "$out" == *"sanitizer"* || "$out" == *"runtime error"* \
+              || "$out" == *"stack-buffer-overflow"* ]]; then
+            bad "${sink%% *} with $k filters — sanitizer report"
+            echo "$out" | grep -m1 -E "ERROR|runtime error" | sed 's/^/        /'
+            sweep_ok=0
+            break 2
+        fi
+    done
+done
+(( sweep_ok )) && ok "1..24 chained filters on both sink paths, no sanitizer findings"
+
+reject "an over-long device number" --camera X --v4l2-sink "/dev/video$(printf '9%.0s' {1..100})"
+
+echo
 echo "── a trusted plugin path is still accepted ──"
 # Validation is the only thing under test here: the exec that follows needs a
 # real camera, so anything past argument parsing counts as accepted.
-out=$("$TMP/launcher" --camera X --fd-sink 3 --egl-vendor /usr/share/glvnd/egl_vendor.d/50_mesa.json \
+out=$("$SAN" --camera X --fd-sink 3 --egl-vendor /usr/share/glvnd/egl_vendor.d/50_mesa.json \
         --gst-plugin-path /usr/local/lib --softisp-mode cpu 3>/dev/null 2>&1)
 if [[ "$out" == *"must be under a root-owned"* || "$out" == *"not allowed"* ]]; then
     bad "/usr/local/lib was rejected"

--- a/camera-relay/tests/test-launcher-validation.sh
+++ b/camera-relay/tests/test-launcher-validation.sh
@@ -80,6 +80,35 @@ reject "traversal out of a trusted prefix" --camera X --fd-sink 3 \
 reject "IPA path in /tmp"      --camera X --fd-sink 3 --ipa-path /tmp/evil
 
 echo
+echo "── EGL vendor pin picks the debayer's driver, so it is validated too ──"
+reject "ICD in \$HOME"        --camera X --fd-sink 3 --egl-vendor "$HOME/evil.json"
+reject "ICD in /tmp"          --camera X --fd-sink 3 --egl-vendor /tmp/evil.json
+reject "traversal"            --camera X --fd-sink 3 \
+    --egl-vendor '/usr/share/glvnd/egl_vendor.d/../../../tmp/evil.json'
+reject "poisoned entry in a list" --camera X --fd-sink 3 \
+    --egl-vendor '/usr/share/glvnd/egl_vendor.d/50_mesa.json:/tmp/evil.json'
+reject "empty value"          --camera X --fd-sink 3 --egl-vendor ''
+
+echo
+echo "── path options are validated on the --list-cameras path too ──"
+# This branch also exports them into the child environment; skipping validation
+# there would hand the group away just as effectively.
+for opt in --ipa-path --gst-plugin-path; do
+    out=$("$TMP/launcher" --list-cameras "$opt" /tmp/evil 2>&1)
+    if [[ $? -ne 0 && "$out" == *"root-owned"* ]]; then
+        ok "--list-cameras $opt /tmp/evil"
+    else
+        bad "--list-cameras $opt /tmp/evil — not validated"
+    fi
+done
+out=$("$TMP/launcher" --list-cameras --egl-vendor /tmp/evil.json 2>&1)
+if [[ $? -ne 0 && "$out" == *"root-owned"* ]]; then
+    ok "--list-cameras --egl-vendor /tmp/evil.json"
+else
+    bad "--list-cameras --egl-vendor /tmp/evil.json — not validated"
+fi
+
+echo
 echo "── sinks ──"
 reject "no sink"                 --camera X
 reject "both sinks"              --camera X --fd-sink 3 --v4l2-sink /dev/video0
@@ -90,7 +119,7 @@ echo
 echo "── a trusted plugin path is still accepted ──"
 # Validation is the only thing under test here: the exec that follows needs a
 # real camera, so anything past argument parsing counts as accepted.
-out=$("$TMP/launcher" --camera X --fd-sink 3 \
+out=$("$TMP/launcher" --camera X --fd-sink 3 --egl-vendor /usr/share/glvnd/egl_vendor.d/50_mesa.json \
         --gst-plugin-path /usr/local/lib --softisp-mode cpu 3>/dev/null 2>&1)
 if [[ "$out" == *"must be under a root-owned"* || "$out" == *"not allowed"* ]]; then
     bad "/usr/local/lib was rejected"

--- a/camera-relay/tests/test-launcher-validation.sh
+++ b/camera-relay/tests/test-launcher-validation.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# The raw IPU6/IPU7 ISYS nodes belong to a memberless 'camera-relay' group so
+# that ordinary applications cannot open them; camera-relay-gst is setgid to
+# that group so the one process that legitimately drives the camera still can.
+#
+# That makes the launcher's input validation load-bearing. If a caller can talk
+# it into running an element of their choosing, or into loading a plugin from a
+# directory they control, they get the group back and the nodes are exposed
+# again. These tests pin that behaviour down.
+#
+# Usage: ./test-launcher-validation.sh
+# Requires no camera hardware and touches no system state (builds into a
+# temporary directory; the binary under test is never setgid here).
+
+set -uo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay-gst.c"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-launcher-validation ($SRC)"
+
+if [[ ! -f "$SRC" ]]; then
+    echo "  ✗ camera-relay-gst.c not found"
+    exit 1
+fi
+if ! command -v gcc >/dev/null 2>&1; then
+    echo "  – skipped: gcc not available"
+    exit 0
+fi
+if ! gcc -O2 -Wall -Werror -o "$TMP/launcher" "$SRC" 2>"$TMP/build.log"; then
+    echo "  ✗ build failed:"
+    sed 's/^/      /' "$TMP/build.log"
+    exit 1
+fi
+ok "builds clean with -Wall -Werror"
+
+# fd 3 is opened for every run so the --fd-sink liveness check is not what
+# rejects these; each case must fail for the reason under test.
+reject() {
+    local desc="$1"; shift
+    local out
+    out=$("$TMP/launcher" "$@" 3>/dev/null 2>&1)
+    if [[ $? -eq 0 ]]; then
+        bad "$desc — accepted"
+    elif [[ "$out" == *"is not open"* ]]; then
+        bad "$desc — rejected by the fd check, not the rule under test"
+    else
+        ok "$desc"
+    fi
+}
+
+echo
+echo "── camera name cannot carry pipeline syntax ──"
+reject "'!' in the camera name"        --camera 'X ! filesink location=/tmp/pwn' --fd-sink 3
+reject "whitespace in the camera name" --camera 'X filesink'                     --fd-sink 3
+reject "quotes in the camera name"     --camera 'a"b'                            --fd-sink 3
+
+echo
+echo "── color filter admits only allow-listed video filters ──"
+reject "a sink element"        --camera X --fd-sink 3 --color-filter 'filesink location=/tmp/pwn'
+reject "a source element"      --camera X --fd-sink 3 --color-filter 'souphttpsrc location=http://x'
+reject "a sink after a filter" --camera X --fd-sink 3 \
+    --color-filter 'videobalance saturation=0.85 ! filesink location=/tmp/pwn'
+reject "a path in a property"  --camera X --fd-sink 3 --color-filter 'videobalance x=/etc/shadow'
+reject "a dangling separator"  --camera X --fd-sink 3 --color-filter 'videobalance !'
+
+echo
+echo "── code-loading paths must be root-owned ──"
+reject "plugin path in \$HOME" --camera X --fd-sink 3 --gst-plugin-path "$HOME/evil"
+reject "plugin path in /tmp"   --camera X --fd-sink 3 --gst-plugin-path /tmp/evil
+reject "traversal out of a trusted prefix" --camera X --fd-sink 3 \
+    --gst-plugin-path '/usr/local/lib/../../tmp/evil'
+reject "IPA path in /tmp"      --camera X --fd-sink 3 --ipa-path /tmp/evil
+
+echo
+echo "── sinks ──"
+reject "no sink"                 --camera X
+reject "both sinks"              --camera X --fd-sink 3 --v4l2-sink /dev/video0
+reject "sink outside /dev/video" --camera X --v4l2-sink /dev/../etc/passwd
+reject "--list-cameras mixed with a pipeline" --camera X --fd-sink 3 --list-cameras
+
+echo
+echo "── a trusted plugin path is still accepted ──"
+# Validation is the only thing under test here: the exec that follows needs a
+# real camera, so anything past argument parsing counts as accepted.
+out=$("$TMP/launcher" --camera X --fd-sink 3 \
+        --gst-plugin-path /usr/local/lib --softisp-mode cpu 3>/dev/null 2>&1)
+if [[ "$out" == *"must be under a root-owned"* || "$out" == *"not allowed"* ]]; then
+    bad "/usr/local/lib was rejected"
+else
+    ok "/usr/local/lib accepted"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/camera-relay/v4l2-io-mc.c
+++ b/camera-relay/v4l2-io-mc.c
@@ -1,0 +1,80 @@
+/*
+ * camera-relay-v4l2-io-mc — udev IMPORT helper: is this node MC-centric?
+ *
+ * The IPU6/IPU7 ISYS drivers register one V4L2 capture node per possible
+ * stream — 48 of them on a Galaxy Book4. None is a usable standalone
+ * camera: they only produce frames after userspace configures the media
+ * graph. The kernel says so via V4L2_CAP_IO_MC ("there is only one input
+ * and/or output ... configured by userspace via the Media Controller").
+ *
+ * Nothing propagates that bit to udev. systemd's v4l_id derives
+ * ID_V4L_CAPABILITIES from V4L2_CAP_VIDEO_CAPTURE alone and never looks at
+ * V4L2_CAP_IO_MC, so all 48 advertise themselves as cameras and show up in
+ * every application's device picker.
+ *
+ * This exports the missing bit so rules can key off the kernel's own
+ * discriminator instead of matching driver-specific card names.
+ *
+ * Output (udev key=value on stdout):
+ *   ID_V4L_IO_MC=1  — MC-centric, not a standalone camera
+ *   ID_V4L_IO_MC=0  — ordinary video-node-centric device
+ *
+ * Exits non-zero without printing when the device cannot be queried, so a
+ * failed probe leaves any value already in the udev database untouched
+ * rather than downgrading the node.
+ *
+ * Build:  gcc -O2 -Wall -o camera-relay-v4l2-io-mc v4l2-io-mc.c
+ * Usage:  camera-relay-v4l2-io-mc /dev/video0
+ */
+
+#define _GNU_SOURCE
+#include <errno.h>
+#include <fcntl.h>
+#include <linux/videodev2.h>
+#include <stdio.h>
+#include <string.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+/* Added in Linux 5.9; define for builds against older UAPI headers. */
+#ifndef V4L2_CAP_IO_MC
+#define V4L2_CAP_IO_MC 0x20000000
+#endif
+
+int main(int argc, char *argv[])
+{
+	struct v4l2_capability cap;
+	unsigned int caps;
+	int fd, ret;
+
+	if (argc != 2) {
+		fprintf(stderr, "usage: %s DEVNODE\n", argv[0]);
+		return 1;
+	}
+
+	/* O_NONBLOCK so a device that would block on open cannot stall udev. */
+	fd = open(argv[1], O_RDONLY | O_NONBLOCK | O_CLOEXEC);
+	if (fd < 0) {
+		fprintf(stderr, "%s: open: %s\n", argv[1], strerror(errno));
+		return 1;
+	}
+
+	do {
+		ret = ioctl(fd, VIDIOC_QUERYCAP, &cap);
+	} while (ret < 0 && errno == EINTR);
+
+	if (ret < 0) {
+		fprintf(stderr, "%s: VIDIOC_QUERYCAP: %s\n", argv[1], strerror(errno));
+		close(fd);
+		return 1;
+	}
+	close(fd);
+
+	/* device_caps describes this node; capabilities describes the whole
+	 * device. Same precedence systemd's v4l_id uses. */
+	caps = (cap.capabilities & V4L2_CAP_DEVICE_CAPS) ? cap.device_caps
+							 : cap.capabilities;
+
+	printf("ID_V4L_IO_MC=%d\n", (caps & V4L2_CAP_IO_MC) ? 1 : 0);
+	return 0;
+}

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -192,12 +192,16 @@ The install script creates these files:
 |------|---------|
 | `/etc/modules-load.d/ivsc.conf` | IVSC module auto-loading at boot |
 | `/etc/modprobe.d/ivsc-camera.conf` | Softdep: IVSC loads before sensor |
-| `/etc/udev/rules.d/90-hide-ipu6-v4l2.rules` | Remove uaccess from raw IPU6 V4L2 nodes |
+| `/etc/udev/rules.d/74-camera-relay-mc-nodes.rules` | Move MC-centric V4L2 nodes to the `camera-relay` group, strip their session ACL, and stop them advertising as cameras (the `74-` prefix is load-bearing — see the comment in the file) |
+| `/usr/local/lib/udev/camera-relay-v4l2-io-mc` | udev helper: reports `V4L2_CAP_IO_MC` for a node |
+| `/usr/local/lib/sysusers.d/camera-relay.conf` | Declares the memberless `camera-relay` group |
 | `/etc/wireplumber/wireplumber.conf.d/50-disable-ipu6-v4l2.conf` | Hide raw IPU6 nodes from PipeWire (WP 0.5+) |
 | `/etc/wireplumber/main.lua.d/51-disable-ipu6-v4l2.lua` | Hide raw IPU6 nodes from PipeWire (WP 0.4) |
 | `/usr/share/libcamera/ipa/simple/ov02c10.yaml` | Sensor color tuning with CCM |
 | `/usr/local/bin/camera-relay` | On-demand camera relay CLI tool |
 | `/usr/local/bin/camera-relay-monitor` | V4L2 event monitor for on-demand activation |
+| `/usr/local/bin/camera-relay-gst` | setgid launcher: the only thing that can open the raw camera nodes |
+| `/var/cache/camera-relay/` | GStreamer/Mesa caches for the pipeline (root-owned, group-writable) |
 | `/etc/modules-load.d/v4l2loopback.conf` | Load v4l2loopback module at boot |
 | `/etc/modprobe.d/99-camera-relay-loopback.conf` | v4l2loopback config for camera relay |
 | `/usr/local/share/camera-relay/camera-relay-systray.py` | System tray GUI |
@@ -279,7 +283,21 @@ cd ov02c10-26mhz-fix && sudo ./install.sh
 
 ### Too many "ipu6" entries in camera list
 
-Log out and back in for the udev rules and WirePlumber config to take effect. The rules hide raw IPU6 V4L2 nodes so only the libcamera source and Camera Relay appear.
+Log out and back in for the udev rules and WirePlumber config to take effect, then check with:
+
+```bash
+camera-relay doctor
+```
+
+The `MC nodes` line reports whether any raw node is still reachable from your session — those are exactly the ones that show up as spurious "ipu6" cameras.
+
+The ISYS driver registers one capture node per possible stream (48 on a Book4), and the kernel marks each `V4L2_CAP_IO_MC`: usable only after userspace configures the media graph, never as a standalone camera. Nothing carries that bit into udev, so they all claim to be cameras. The installer therefore moves them into a memberless `camera-relay` group and clears the bogus properties, which covers both kinds of application — the ones that enumerate through udev (Chromium and friends) and the ones that walk `/dev/video*` calling `QUERYCAP` and only skip what they cannot open (Firefox, Zoom, OBS).
+
+One consequence: `cam` and `qcam` can no longer open the camera as your user. Run them through the launcher, which holds the group:
+
+```bash
+camera-relay-gst --list-cameras
+```
 
 ### Zoom / OBS / VLC don't see the camera
 

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1505,11 +1505,38 @@ echo "  ✓ Group 'camera-relay' present (no members by design)"
 sudo install -d -m 2770 -o root -g camera-relay /var/cache/camera-relay
 
 MC_HELPER=/usr/local/lib/udev/camera-relay-v4l2-io-mc
+
+# Ordering here is a safety property, not tidiness. The moment the rule below
+# takes effect the raw nodes belong to 'camera-relay', and the only thing that
+# can still open them is the setgid launcher — so the launcher has to exist
+# first. Build both helpers up front and install the rule only if both are in
+# place; if either fails, the nodes keep their old ownership and the camera
+# keeps working with the spurious entries still listed. A degraded camera list
+# beats a camera nothing can open.
+MC_HELPER_OK=""
+LAUNCHER_OK=""
 if gcc -O2 -Wall -o /tmp/camera-relay-v4l2-io-mc "$CAMERA_RELAY_SRC/v4l2-io-mc.c" 2>/dev/null; then
     sudo install -d -m 755 /usr/local/lib/udev
     sudo install -m 755 /tmp/camera-relay-v4l2-io-mc "$MC_HELPER"
     rm -f /tmp/camera-relay-v4l2-io-mc
+    MC_HELPER_OK=1
+fi
 
+if [[ -f "$CAMERA_RELAY_SRC/camera-relay-gst.c" ]] \
+   && gcc -O2 -Wall -o /tmp/camera-relay-gst "$CAMERA_RELAY_SRC/camera-relay-gst.c" 2>/dev/null; then
+    sudo install -o root -g camera-relay -m 755 \
+        /tmp/camera-relay-gst /usr/local/bin/camera-relay-gst
+    # After the group change: chgrp clears S_ISGID, so `install -m 2755 -g ...`
+    # silently lands as plain 0755 and the launcher cannot reach the nodes.
+    sudo chmod 2755 /usr/local/bin/camera-relay-gst
+    rm -f /tmp/camera-relay-gst
+    LAUNCHER_OK=1
+    echo "  ✓ Installed /usr/local/bin/camera-relay-gst (setgid camera-relay)"
+else
+    echo "  ⚠ Failed to build the pipeline launcher (gcc required)."
+fi
+
+if [[ -n "$MC_HELPER_OK" && -n "$LAUNCHER_OK" ]]; then
     sudo tee /etc/udev/rules.d/74-camera-relay-mc-nodes.rules > /dev/null << 'EOF'
 # Raw MC-centric V4L2 nodes are not standalone cameras. Keyed off the kernel's
 # own V4L2_CAP_IO_MC rather than a driver-specific card name, so this covers
@@ -1572,7 +1599,9 @@ EOF
     sudo udevadm trigger --action=change --subsystem-match=video4linux
     echo "  ✓ Raw MC-centric nodes reassigned to the camera-relay group"
 else
-    echo "  ⚠ Failed to build the IO_MC udev helper (gcc required)."
+    # Deliberately leave the nodes alone. Reassigning them without a launcher
+    # to reach them would take the camera out entirely.
+    echo "  ⚠ Skipping the MC-node rule — the helpers did not build (gcc required)."
     echo "    Raw nodes stay visible in app camera lists; the camera still works."
 fi
 
@@ -1878,26 +1907,9 @@ EOF
         fi
     fi
 
-    # Build and install the setgid pipeline launcher (C binary).
-    # Raw camera nodes belong to the memberless 'camera-relay' group, so the
-    # pipeline needs this to reach them. setgid, not setuid — the UID stays the
-    # user's, which is what keeps the EGL context, the uaccess ACLs and the
-    # monitor's same-UID /proc scan working.
-    if [[ -f "$RELAY_DIR/camera-relay-gst.c" ]]; then
-        echo "  Building pipeline launcher..."
-        if gcc -O2 -Wall -o /tmp/camera-relay-gst "$RELAY_DIR/camera-relay-gst.c"; then
-            sudo install -o root -g camera-relay -m 755 \
-                /tmp/camera-relay-gst /usr/local/bin/camera-relay-gst
-            # Must come after the group change: chgrp clears S_ISGID, so
-            # `install -m 2755 -g ...` silently lands as plain 0755.
-            sudo chmod 2755 /usr/local/bin/camera-relay-gst
-            rm -f /tmp/camera-relay-gst
-            echo "  ✓ Installed /usr/local/bin/camera-relay-gst (setgid camera-relay)"
-        else
-            echo "  ⚠ Failed to build the launcher (gcc required) — the relay"
-            echo "    cannot reach the camera nodes without it."
-        fi
-    fi
+    # The setgid launcher is built in step 12, before the udev rule hands the
+    # raw nodes to the camera-relay group — it has to exist before anything
+    # depends on it. Nothing to do here.
 
     # Install CLI tool
     sudo cp "$RELAY_DIR/camera-relay" /usr/local/bin/camera-relay

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1329,7 +1329,11 @@ if [[ -n "$LOCAL_IPA_DIR" ]]; then
     export LIBCAMERA_IPA_MODULE_PATH="$LOCAL_IPA_DIR"
 fi
 
-# Ensure user is in video group (needed for non-root camera access)
+# Ensure user is in video group. This is no longer what grants access to the
+# raw camera nodes — those move to the memberless 'camera-relay' group in step
+# 12, and both the loopback and /dev/media0 carry their own uaccess ACL. Kept
+# because the group still covers other video devices and setups where uaccess
+# does not apply (no logind seat).
 CURRENT_USER="${SUDO_USER:-$USER}"
 if ! groups "$CURRENT_USER" 2>/dev/null | grep -q '\bvideo\b'; then
     sudo usermod -aG video "$CURRENT_USER"
@@ -1463,17 +1467,114 @@ fi
 echo ""
 echo "[12/14] Hiding raw IPU6 nodes from applications..."
 
-# Remove session-level ACL from raw V4L2 nodes (keeps file permissions intact
-# so libcamera can still access them via the video group)
-sudo tee /etc/udev/rules.d/90-hide-ipu6-v4l2.rules > /dev/null << 'EOF'
-# Remove uaccess tag from raw Intel IPU6 ISYS V4L2 nodes.
-# libcamera accesses these via /dev/media0 and the video device nodes.
-# TAG-="uaccess" removes session-level permissions added by systemd.
-SUBSYSTEM=="video4linux", KERNEL=="video*", ATTR{name}=="Intel IPU6 ISYS Capture*", TAG-="uaccess"
-SUBSYSTEM=="video4linux", KERNEL=="video*", ATTR{name}=="Intel IPU6 CSI2*", TAG-="uaccess"
+# The ISYS driver registers one capture node per possible stream — 48 on a
+# Book4 — and the kernel flags each one V4L2_CAP_IO_MC: usable only once
+# userspace has configured the media graph, never as a standalone camera.
+# Nothing carries that bit into udev (systemd's v4l_id derives
+# ID_V4L_CAPABILITIES from V4L2_CAP_VIDEO_CAPTURE alone and never looks at
+# IO_MC), so all 48 advertise themselves as cameras.
+#
+# Applications split into two groups needing different answers:
+#   - Chromium and friends enumerate through udev, so clearing the capability
+#     properties is enough to drop them from those pickers.
+#   - Firefox/libwebrtc walks /dev/video0..63 calling QUERYCAP, ignores udev
+#     entirely, and only skips a node whose open() fails. Permissions are the
+#     only lever that works there.
+#
+# Hence the dedicated group: the nodes move out of 'video' (which the desktop
+# user is in, so it granted access no matter what happened to the uaccess tag)
+# into a group with no members. The relay's pipeline gets it from the setgid
+# launcher instead — see camera-relay-gst.c.
+CAMERA_RELAY_SRC="$SCRIPT_DIR/../camera-relay"
+
+sudo mkdir -p /usr/local/lib/sysusers.d
+sudo tee /usr/local/lib/sysusers.d/camera-relay.conf > /dev/null << 'EOF'
+# Owns the raw MC-centric camera nodes. Deliberately memberless: the relay
+# pipeline acquires it through the setgid launcher, nothing else should hold it.
+g camera-relay -
 EOF
-sudo udevadm control --reload-rules
-sudo udevadm trigger --action=change --subsystem-match=video4linux
+command -v systemd-sysusers >/dev/null 2>&1 && sudo systemd-sysusers >/dev/null 2>&1 || true
+if ! getent group camera-relay >/dev/null 2>&1; then
+    sudo groupadd -r camera-relay
+fi
+echo "  ✓ Group 'camera-relay' present (no members by design)"
+
+# Writable state for the pipeline's own caches. The GStreamer registry maps
+# elements to .so paths that get dlopen()ed, so it must not live anywhere the
+# user can write — that would hand the group back through a poisoned cache.
+sudo install -d -m 2770 -o root -g camera-relay /var/cache/camera-relay
+
+MC_HELPER=/usr/local/lib/udev/camera-relay-v4l2-io-mc
+if gcc -O2 -Wall -o /tmp/camera-relay-v4l2-io-mc "$CAMERA_RELAY_SRC/v4l2-io-mc.c" 2>/dev/null; then
+    sudo install -d -m 755 /usr/local/lib/udev
+    sudo install -m 755 /tmp/camera-relay-v4l2-io-mc "$MC_HELPER"
+    rm -f /tmp/camera-relay-v4l2-io-mc
+
+    sudo tee /etc/udev/rules.d/74-camera-relay-mc-nodes.rules > /dev/null << 'EOF'
+# Raw MC-centric V4L2 nodes are not standalone cameras. Keyed off the kernel's
+# own V4L2_CAP_IO_MC rather than a driver-specific card name, so this covers
+# IPU6, IPU7 and anything else media-controller based.
+#
+# The 74- prefix is load-bearing, pinned by three stock rule files:
+#   60-persistent-v4l.rules  runs v4l_id, which sets the properties cleared below
+#   73-seat-late.rules       queues RUN{builtin}+="uaccess", the session ACL
+#   95-cd-devices.rules      hands anything with ID_V4L_PRODUCT to colord
+#
+# Note what does NOT work, because it looks like it should: TAG-="uaccess" on
+# its own. 70-uaccess.rules tags every video4linux device unconditionally, and
+# the TAG== test in 73 matches the *sticky* tag list, which TAG-= does not
+# touch. So the ACL is granted no matter where this file sits, and the node
+# stays openable — which is what kept the nodes visible in app pickers even
+# with a rule that appeared to remove the tag. Stripping the ACL afterwards is
+# the reliable option: RUN entries execute in the order rules added them, so
+# the setfacl below lands after 73's builtin.
+#
+# TAG-= is still worth keeping. It clears the *current* tag list, which is what
+# logind re-enumerates when a session becomes active — without it the ACL comes
+# back on the next login.
+ACTION=="remove", GOTO="camera_relay_mc_end"
+SUBSYSTEM!="video4linux", GOTO="camera_relay_mc_end"
+
+# Only probe when the classification is not already known. udev runs as root,
+# so opening the node succeeds even after the group change below.
+KERNEL=="video*", ENV{ID_V4L_IO_MC}=="", \
+  IMPORT{program}="/usr/local/lib/udev/camera-relay-v4l2-io-mc $devnode"
+
+# Out of 'video' (the desktop user is in it), and no longer claiming to be a
+# camera. Clearing ID_V4L_PRODUCT is what stops colord: 95-cd-devices.rules
+# keys on the product name, not on the capabilities.
+ENV{ID_V4L_IO_MC}=="1", GROUP="camera-relay", MODE="0660", TAG-="uaccess", \
+  ENV{ID_V4L_CAPABILITIES}="", ENV{ID_V4L_PRODUCT}="", \
+  RUN+="/usr/bin/setfacl -b $devnode"
+
+LABEL="camera_relay_mc_end"
+EOF
+
+    # Superseded: matched card names instead of the capability, and only
+    # dropped the uaccess tag while the 'video' group kept granting access —
+    # so it never actually hid anything.
+    sudo rm -f /etc/udev/rules.d/90-hide-ipu6-v4l2.rules
+    # Earlier revisions of this fix; both relied on TAG-= alone, which cannot
+    # stop the uaccess ACL (see the header of the rule above).
+    sudo rm -f /etc/udev/rules.d/90-camera-relay-mc-nodes.rules \
+               /etc/udev/rules.d/72-camera-relay-mc-nodes.rules
+
+    # The rule strips the session ACL with setfacl; without it the raw nodes
+    # stay open to the desktop user and keep showing up in camera lists.
+    if [[ ! -x /usr/bin/setfacl ]]; then
+        echo "  ⚠ /usr/bin/setfacl missing — install the 'acl' package, otherwise"
+        echo "    the raw nodes keep their session ACL and stay visible in apps."
+    fi
+
+    sudo udevadm control --reload-rules
+    # The rule's own RUN strips the ACL, so this trigger fixes the running
+    # session too — no reboot needed.
+    sudo udevadm trigger --action=change --subsystem-match=video4linux
+    echo "  ✓ Raw MC-centric nodes reassigned to the camera-relay group"
+else
+    echo "  ⚠ Failed to build the IO_MC udev helper (gcc required)."
+    echo "    Raw nodes stay visible in app camera lists; the camera still works."
+fi
 
 # WirePlumber rule to hide raw IPU6 V4L2 nodes from PipeWire
 # This prevents ~48 unusable "ipu6 (V4L2)" entries in app camera lists.
@@ -1777,6 +1878,27 @@ EOF
         fi
     fi
 
+    # Build and install the setgid pipeline launcher (C binary).
+    # Raw camera nodes belong to the memberless 'camera-relay' group, so the
+    # pipeline needs this to reach them. setgid, not setuid — the UID stays the
+    # user's, which is what keeps the EGL context, the uaccess ACLs and the
+    # monitor's same-UID /proc scan working.
+    if [[ -f "$RELAY_DIR/camera-relay-gst.c" ]]; then
+        echo "  Building pipeline launcher..."
+        if gcc -O2 -Wall -o /tmp/camera-relay-gst "$RELAY_DIR/camera-relay-gst.c"; then
+            sudo install -o root -g camera-relay -m 755 \
+                /tmp/camera-relay-gst /usr/local/bin/camera-relay-gst
+            # Must come after the group change: chgrp clears S_ISGID, so
+            # `install -m 2755 -g ...` silently lands as plain 0755.
+            sudo chmod 2755 /usr/local/bin/camera-relay-gst
+            rm -f /tmp/camera-relay-gst
+            echo "  ✓ Installed /usr/local/bin/camera-relay-gst (setgid camera-relay)"
+        else
+            echo "  ⚠ Failed to build the launcher (gcc required) — the relay"
+            echo "    cannot reach the camera nodes without it."
+        fi
+    fi
+
     # Install CLI tool
     sudo cp "$RELAY_DIR/camera-relay" /usr/local/bin/camera-relay
     sudo chmod 755 /usr/local/bin/camera-relay
@@ -1938,7 +2060,10 @@ echo ""
 echo "  Configuration files created:"
 echo "    /etc/modules-load.d/ivsc.conf"
 echo "    /etc/modprobe.d/ivsc-camera.conf"
-echo "    /etc/udev/rules.d/90-hide-ipu6-v4l2.rules"
+echo "    /etc/udev/rules.d/74-camera-relay-mc-nodes.rules"
+[[ -f /usr/local/lib/udev/camera-relay-v4l2-io-mc ]] && \
+    echo "    /usr/local/lib/udev/camera-relay-v4l2-io-mc"
+echo "    /usr/local/lib/sysusers.d/camera-relay.conf"
 [[ -f /etc/initramfs-tools/modules ]] && echo "    /etc/initramfs-tools/modules (updated)"
 [[ -f /etc/dracut.conf.d/ivsc-camera.conf ]] && echo "    /etc/dracut.conf.d/ivsc-camera.conf"
 [[ -f /etc/mkinitcpio.conf.d/ivsc-camera.conf ]] && echo "    /etc/mkinitcpio.conf.d/ivsc-camera.conf"
@@ -1957,6 +2082,8 @@ echo "    /usr/local/share/libcamera/ipa/simple/ov02c10.yaml"
 if [[ -f /usr/local/bin/camera-relay ]]; then
     echo "    /usr/local/bin/camera-relay"
     echo "    /usr/local/bin/camera-relay-monitor"
+    [[ -f /usr/local/bin/camera-relay-gst ]] && \
+        echo "    /usr/local/bin/camera-relay-gst"
     echo "    /etc/modprobe.d/99-camera-relay-loopback.conf"
 fi
 echo ""

--- a/webcam-fix-libcamera/uninstall.sh
+++ b/webcam-fix-libcamera/uninstall.sh
@@ -28,6 +28,8 @@ pkill -f "camera-relay start" 2>/dev/null || true
 # Remove binaries and config
 sudo rm -f /usr/local/bin/camera-relay
 sudo rm -f /usr/local/bin/camera-relay-monitor
+sudo rm -f /usr/local/bin/camera-relay-gst
+sudo rm -rf /var/cache/camera-relay
 sudo rm -f /etc/modprobe.d/99-camera-relay-loopback.conf
 sudo rm -f /etc/modules-load.d/v4l2loopback.conf
 # Restore the Intel OEM v4l2-relayd stack if install.sh neutralized it (issue #54)
@@ -116,8 +118,19 @@ fi
 # [4/8] Remove udev rules
 echo "[4/8] Removing udev rules..."
 sudo rm -f /etc/udev/rules.d/90-hide-ipu6-v4l2.rules
+sudo rm -f /etc/udev/rules.d/74-camera-relay-mc-nodes.rules
+sudo rm -f /etc/udev/rules.d/72-camera-relay-mc-nodes.rules
+sudo rm -f /etc/udev/rules.d/90-camera-relay-mc-nodes.rules
 sudo rm -f /etc/udev/rules.d/70-camera-relay-capabilities.rules
+sudo rm -f /usr/local/lib/udev/camera-relay-v4l2-io-mc
+sudo rm -f /usr/local/lib/sysusers.d/camera-relay.conf
 sudo udevadm control --reload-rules 2>/dev/null || true
+# Hand the raw nodes back to their default ownership, otherwise they stay in a
+# group nothing recreates and the camera is unreachable until the next boot.
+sudo udevadm trigger --action=change --subsystem-match=video4linux 2>/dev/null || true
+if getent group camera-relay >/dev/null 2>&1; then
+    sudo groupdel camera-relay 2>/dev/null || true
+fi
 echo "  ✓ Udev rules removed"
 
 # [5/8] Remove WirePlumber rules

--- a/webcam-fix-libcamera/uninstall.sh
+++ b/webcam-fix-libcamera/uninstall.sh
@@ -15,6 +15,25 @@ if [[ $EUID -eq 0 ]]; then
     exit 1
 fi
 
+# Hand the raw camera nodes back before anything else, mirroring the order
+# install.sh builds them up in. While 74-camera-relay-mc-nodes.rules is live the
+# nodes belong to the memberless camera-relay group and only the setgid launcher
+# can open them — so removing the launcher first opens exactly the dead-camera
+# window the installer was reordered to avoid, and `set -e` above would make it
+# permanent. This script is what someone reaches for to recover from a broken
+# state, so it is the worst possible place to leave that window.
+#
+# Reverting ownership first means a failure anywhere below lands on "the
+# spurious nodes are back and the camera works".
+echo "[0/8] Restoring raw camera node ownership..."
+sudo rm -f /etc/udev/rules.d/74-camera-relay-mc-nodes.rules
+# Earlier names for the same rule, from revisions that relied on TAG-= alone.
+sudo rm -f /etc/udev/rules.d/72-camera-relay-mc-nodes.rules \
+           /etc/udev/rules.d/90-camera-relay-mc-nodes.rules
+sudo udevadm control --reload-rules 2>/dev/null || true
+sudo udevadm trigger --action=change --subsystem-match=video4linux 2>/dev/null || true
+echo "  ✓ Raw nodes back to their default ownership"
+
 # [1/8] Stop and remove camera relay
 echo "[1/8] Removing camera relay..."
 # Disable persistent mode (stops user service, removes unit file)
@@ -117,16 +136,13 @@ fi
 
 # [4/8] Remove udev rules
 echo "[4/8] Removing udev rules..."
+# The MC-node rule is already gone — step 0 removes it before the launcher, so
+# the nodes are never group-owned without something able to open them.
 sudo rm -f /etc/udev/rules.d/90-hide-ipu6-v4l2.rules
-sudo rm -f /etc/udev/rules.d/74-camera-relay-mc-nodes.rules
-sudo rm -f /etc/udev/rules.d/72-camera-relay-mc-nodes.rules
-sudo rm -f /etc/udev/rules.d/90-camera-relay-mc-nodes.rules
 sudo rm -f /etc/udev/rules.d/70-camera-relay-capabilities.rules
 sudo rm -f /usr/local/lib/udev/camera-relay-v4l2-io-mc
 sudo rm -f /usr/local/lib/sysusers.d/camera-relay.conf
 sudo udevadm control --reload-rules 2>/dev/null || true
-# Hand the raw nodes back to their default ownership, otherwise they stay in a
-# group nothing recreates and the camera is unreachable until the next boot.
 sudo udevadm trigger --action=change --subsystem-match=video4linux 2>/dev/null || true
 if getent group camera-relay >/dev/null 2>&1; then
     sudo groupdel camera-relay 2>/dev/null || true


### PR DESCRIPTION
The installer promises that the ~48 raw IPU6 nodes stay out of application camera lists. They don't — here they are in Zen (Firefox-based), and they show up in Zoom, OBS and colord too.

## Why the current rule can't work

`90-hide-ipu6-v4l2.rules` fails for two independent reasons, either of which is enough on its own.

**It targets the wrong thing.** The rule only does `TAG-="uaccess"`, but [`install.sh:1332`](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/blob/main/webcam-fix-libcamera/install.sh#L1332) adds the user to `video` and the nodes are `root:video 0660`. The group is what grants access, so removing the session ACL tag changes nothing. On my machine `/dev/video1` had no ACL and `open()` still succeeded.

**`TAG-="uaccess"` can't stop the ACL anyway.** `70-uaccess.rules` tags every `video4linux` device unconditionally, and the `TAG==` test in `73-seat-late.rules` matches the *sticky* tag list, which `TAG-=` doesn't touch. `udevadm test` shows it plainly:

```
CURRENT_TAGS=:uaccess:seat:...      ← TAG-= did remove it here
TAGS=:uaccess:...                   ← but 73 matches this one
Queued commands:
  RUN{builtin} : uaccess
```

No rule priority fixes that, and `70-uaccess.rules` has no usable early exit.

## The kernel already tells us

The ISYS driver sets **`V4L2_CAP_IO_MC`** on all 48 nodes — they only produce frames once userspace configures the media graph, and are never usable as standalone cameras. The loopback doesn't have the bit:

```
/dev/video1  Device Caps 0x24a00001   (I/O MC)
/dev/video0  Device Caps 0x05200003   (Camera Relay)
```

Nothing carries that into udev: systemd's [`v4l_id`](https://github.com/systemd/systemd/blob/main/src/udev/v4l_id/v4l_id.c) derives `ID_V4L_CAPABILITIES` from `V4L2_CAP_VIDEO_CAPTURE` alone and never looks at `IO_MC`. So all 48 claim to be cameras.

## Two kinds of application, two answers

- **Chromium and friends** enumerate through udev — clearing the properties is enough.
- **Firefox/libwebrtc** ([`device_info_v4l2.cc`](https://searchfox.org/mozilla-central/source/third_party/libwebrtc/modules/video_capture/linux/device_info_v4l2.cc)) walks `/dev/video0..63` calling `QUERYCAP`, ignores udev entirely, and only skips a node whose `open()` fails. **Permissions are the only lever there.**

Renaming the nodes out of `/dev/video*` isn't available: udev(7) is explicit that a device node name cannot be changed, only symlinked.

## What this does

- **`v4l2-io-mc.c`** — udev helper exporting the kernel's capability as `ID_V4L_IO_MC`, so the rule keys on that instead of a driver-specific card name. Covers IPU6, IPU7 and anything else media-controller based.
- **`74-camera-relay-mc-nodes.rules`** — moves the nodes to a memberless `camera-relay` group, clears the properties that make them look like cameras (including `ID_V4L_PRODUCT`, since `95-cd-devices.rules` keys on that rather than the capabilities), and strips the ACL with a `RUN` that lands after 73's builtin. The `74-` prefix is load-bearing; the file explains why.
- **`camera-relay-gst.c`** — setgid launcher giving the libcamera pipeline that group. The UID is unchanged, which is what keeps the EGL context for GPU debayer, the uaccess ACLs on the loopback and `/dev/media0`, and the monitor's same-UID `/proc` scan all working. It assembles the pipeline itself rather than running a command line it was handed, and builds a fresh environment instead of filtering the inherited one, since GStreamer and libcamera both load code from paths named by environment variables.

`detect_camera_name` now goes through the launcher as well — `cam -l` is the method actually in use (the PipeWire libcamera node is disabled on purpose) and it can no longer open the nodes as the user. `camera-relay doctor` gained checks for the setgid bit and for any MC node still reachable from the session; both fail silently otherwise. The `--foreground` path picks up `RELAY_COLOR_FILTER` as a side effect — it used to drop it.

## Interaction with #76 (second commit)

Building a fresh environment also drops `__EGL_VENDOR_LIBRARY_FILENAMES`, which is exactly what #76 added to keep the debayer off NVIDIA's EGL driver. Rebasing onto #76 alone was not enough — the launcher has to forward the pin explicitly, or every frame comes out black with #76's own signature:

```
ERROR eGL egl.cpp:134 glFrameBufferTexture2D error 36054
ERROR Debayer debayer_egl.cpp:639 debayerGPU failed
```

So `--egl-vendor` is forwarded and validated, against a narrower prefix list than the other paths (`/etc/glvnd/egl_vendor.d`, `/usr/share/glvnd/egl_vendor.d`) because the value picks which driver runs the debayer. That commit also closes a hole in `--list-cameras`, which exported `--ipa-path`/`--gst-plugin-path` into the child environment without validating them.

## Verification

On a Book4 Ultra (i915 + nvidia), after a **cold boot**:

```
/dev/video1  root camera-relay crw-rw----    ← no ACL
/dev/video0  root video        crw-rw----+   ← untouched
open() video1: denied    open() video0: allowed
leaking: 0 of 48
doctor: Launcher setgid OK | MC nodes hidden OK | EGL_VENDOR: Mesa Project | REAL PICTURE
```

The picker lists only `Camera Relay`:

<img src="https://raw.githubusercontent.com/4nrry/samsung-galaxy-book-linux-fixes/pr-assets/picker-after.png" alt="Camera picker showing a single entry, Camera Relay" width="416">

`tests/test-launcher-validation.sh` covers the launcher's input validation — 26 cases, hardware-free, no system state touched. The existing suite is unchanged at 10/11 with the same pre-existing failure (verified against the pristine script via `git stash`).

## Notes for review

Two things deliberately left out, and one thing worth a closer look.

`webcam-fix-book5` (IPU7) still uses a name-matched rule and would be covered by the same generic `IO_MC` rule — left out because I have no Book5 to validate on.

`install.sh` and `uninstall.sh` are syntax-checked but were never run end to end: this was applied to a live machine by installing the individual pieces in a safe order, not by re-running the installer. The commands themselves are all exercised, but the full installer path is untested.

The setgid binary is the security-sensitive part and deserves a maintainer's eye. The threat model is narrow — the group grants only raw camera access, which the user already reaches through the relay — but it is a permanent fixture, so the two properties it exists to hold (never exec a caller-supplied command line; build a fresh environment rather than filtering the inherited one) are worth checking against `tests/test-launcher-validation.sh`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


