### PR TITLE
camera-relay-monitor: refuse to stream into a format the device didn't take

### DIFF
--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -763,7 +763,12 @@ Run the installer to build it, or use 'camera-relay start' for always-on mode."
 
     # Clean up all children on exit
     cleanup_on_demand() {
-        pkill -P $$ 2>/dev/null
+        # `|| true` is load-bearing: with no children left, pkill exits 1, and a
+        # command failing inside an EXIT trap under set -e replaces the shell's
+        # exit status with its own. That silently turned every status into 1 —
+        # including the monitor's, which is the whole point of the sentinel
+        # above.
+        pkill -P $$ 2>/dev/null || true
         rm -f "$PID_FILE" "$STATE_CACHE"
     }
     trap cleanup_on_demand EXIT
@@ -795,8 +800,11 @@ Run the installer to build it, or use 'camera-relay start' for always-on mode."
                 info "Camera released, resuming idle"
                 ;;
         esac
-    done < <("$MONITOR_BIN" "$loopback_dev" 1920 1080 \
-             -- "${gst_cmd[@]}" 2>"$gst_log"; echo "__monitor_exit:$?")
+    # `|| rc=$?` rather than a bare `; echo ...$?`: the subshell inherits set -e,
+    # so a failing monitor would abort it before the sentinel was ever emitted —
+    # which looks exactly like the bug this is here to prevent.
+    done < <(rc=0; "$MONITOR_BIN" "$loopback_dev" 1920 1080 \
+             -- "${gst_cmd[@]}" 2>"$gst_log" || rc=$?; echo "__monitor_exit:$rc")
 
     if (( monitor_rc != 0 )); then
         warn "Monitor exited with status $monitor_rc — see $gst_log"

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -770,8 +770,18 @@ Run the installer to build it, or use 'camera-relay start' for always-on mode."
 
     # The monitor manages the pipeline subprocess itself.
     # We just read its events for status tracking.
+    #
+    # A process substitution gives no way to observe the child's exit code —
+    # it lands in neither $? nor PIPESTATUS. Without the sentinel below this
+    # function always returned 0, so a monitor that gave up looked like a
+    # clean shutdown and Restart=on-failure never fired: the same shape as the
+    # "Already running" exit-0 bug described above already_running_healthy().
+    local monitor_rc=0
     while IFS= read -r event; do
         case "$event" in
+            __monitor_exit:*)
+                monitor_rc="${event#__monitor_exit:}"
+                ;;
             READY)
                 info "Monitor ready, device visible to apps"
                 ;;
@@ -786,9 +796,13 @@ Run the installer to build it, or use 'camera-relay start' for always-on mode."
                 ;;
         esac
     done < <("$MONITOR_BIN" "$loopback_dev" 1920 1080 \
-             -- "${gst_cmd[@]}" 2>"$gst_log")
+             -- "${gst_cmd[@]}" 2>"$gst_log"; echo "__monitor_exit:$?")
 
+    if (( monitor_rc != 0 )); then
+        warn "Monitor exited with status $monitor_rc — see $gst_log"
+    fi
     info "On-demand relay stopped"
+    return "$monitor_rc"
 }
 
 cmd_stop() {

--- a/camera-relay/camera-relay-monitor.c
+++ b/camera-relay/camera-relay-monitor.c
@@ -191,7 +191,13 @@ static int open_writer(const char *device, int width, int height,
 	}
 
 	/* S_FMT is allowed to adjust what it was given and report the result in
-	 * the same struct, so a successful ioctl is not confirmation. */
+	 * the same struct, so a successful ioctl is not confirmation.
+	 *
+	 * sizeimage is deliberately not compared: for a packed format like YUYV
+	 * it is derived from the geometry, so width/height/pixelformat agreeing
+	 * already pins it. That stops holding the moment this writes anything
+	 * planar or compressed — add the sizeimage check along with the format
+	 * if that ever happens. */
 	if (fmt.fmt.pix.pixelformat != V4L2_PIX_FMT_YUYV ||
 	    fmt.fmt.pix.width != (__u32)width ||
 	    fmt.fmt.pix.height != (__u32)height) {
@@ -429,6 +435,10 @@ int main(int argc, char *argv[])
 		return 1;
 	}
 	pid_t our_pid = getpid();
+	/* Distinguishes "asked to stop" from "gave up". A clean exit tells the
+	 * supervisor everything is fine and Restart=on-failure will not fire, so
+	 * any path that abandons the device has to say so here. */
+	int exit_status = 0;
 
 	/* Open writer and set up device */
 	int fd = open_writer(device, width, height, frame_size, black_frame);
@@ -688,6 +698,7 @@ int main(int argc, char *argv[])
 							"[monitor] "
 							"Re-open "
 							"failed!\n");
+						exit_status = 1;
 						running = 0;
 						break;
 					}
@@ -767,5 +778,5 @@ int main(int argc, char *argv[])
 	free(black_frame);
 	if (fd >= 0)
 		close(fd);
-	return 0;
+	return exit_status;
 }

--- a/camera-relay/camera-relay-monitor.c
+++ b/camera-relay/camera-relay-monitor.c
@@ -139,6 +139,17 @@ static int count_other_openers(dev_t dev_id, pid_t our_pid,
 	return count;
 }
 
+/* Render a FOURCC for humans: 'YUYV', 'MJPG', ... */
+static const char *fourcc(char buf[5], __u32 pixelformat)
+{
+	buf[0] = (char)(pixelformat & 0xff);
+	buf[1] = (char)((pixelformat >> 8) & 0xff);
+	buf[2] = (char)((pixelformat >> 16) & 0xff);
+	buf[3] = (char)((pixelformat >> 24) & 0xff);
+	buf[4] = '\0';
+	return buf;
+}
+
 /* Open device for writing, set format, write initial black frame.
  * Returns fd on success, -1 on failure. */
 static int open_writer(const char *device, int width, int height,
@@ -160,9 +171,47 @@ static int open_writer(const char *device, int width, int height,
 	fmt.fmt.pix.sizeimage = frame_size;
 	fmt.fmt.pix.field = V4L2_FIELD_NONE;
 
-	if (xioctl(fd, VIDIOC_S_FMT, &fmt) < 0)
-		fprintf(stderr, "[monitor] S_FMT warning: %s\n",
-			strerror(errno));
+	/*
+	 * Every frame this process writes is a fixed-size YUYV buffer. If the
+	 * device is on any other format or geometry, those writes are garbage
+	 * to every reader — silently, because the device stays open and the
+	 * relay still reports "streaming".
+	 *
+	 * The loopback only advertises the writer's format while a writer holds
+	 * it; with no writer it offers everything it can carry, and a reader is
+	 * free to select one. So arriving here and finding a foreign format is
+	 * a real possibility, not a theoretical one.
+	 */
+	if (xioctl(fd, VIDIOC_S_FMT, &fmt) < 0) {
+		fprintf(stderr,
+			"[monitor] Cannot set %s to %dx%d YUYV: %s\n",
+			device, width, height, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	/* S_FMT is allowed to adjust what it was given and report the result in
+	 * the same struct, so a successful ioctl is not confirmation. */
+	if (fmt.fmt.pix.pixelformat != V4L2_PIX_FMT_YUYV ||
+	    fmt.fmt.pix.width != (__u32)width ||
+	    fmt.fmt.pix.height != (__u32)height) {
+		char got[5];
+
+		fprintf(stderr,
+			"[monitor] %s stayed on %ux%u %s after asking for "
+			"%dx%d YUYV.\n"
+			"[monitor] Fixed-size YUYV frames written to it would "
+			"be garbage to every\n"
+			"[monitor] reader, so the relay stops here rather than "
+			"stream silently. If an\n"
+			"[monitor] application is holding the device with its "
+			"own format, closing it\n"
+			"[monitor] lets the relay recover on the next start.\n",
+			device, fmt.fmt.pix.width, fmt.fmt.pix.height,
+			fourcc(got, fmt.fmt.pix.pixelformat), width, height);
+		close(fd);
+		return -1;
+	}
 
 	if (write(fd, black_frame, frame_size) != frame_size)
 		fprintf(stderr, "[monitor] Initial write warning: %s\n",

--- a/camera-relay/tests/test-monitor-exit-propagation.sh
+++ b/camera-relay/tests/test-monitor-exit-propagation.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# The on-demand path reads the monitor's event stream through a process
+# substitution:
+#
+#     done < <("$MONITOR_BIN" ... )
+#
+# which gives no way to observe the child's exit code — it lands in neither $?
+# nor PIPESTATUS. So a monitor that gave up looked exactly like a clean
+# shutdown, `camera-relay start --on-demand` exited 0, and Restart=on-failure
+# never fired: the relay stayed dead until someone restarted it by hand.
+#
+# That is the same shape as the "Already running" exit-0 bug fixed in v0.3.56,
+# which is why it is worth a test rather than just a comment.
+#
+# The read loop is lifted out of the script itself rather than retyped here, so
+# deleting the sentinel in camera-relay fails this test instead of silently
+# passing against a stale copy.
+#
+# Usage: ./test-monitor-exit-propagation.sh
+# Requires no camera hardware and touches no system state.
+
+set -uo pipefail
+
+RELAY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay"
+PASS=0
+FAIL=0
+
+ok()  { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad() { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-monitor-exit-propagation ($RELAY)"
+
+# Pull the real read loop out of cmd_start_on_demand: from the comment that
+# introduces it through the closing `return`.
+sed -n '/# The monitor manages the pipeline subprocess itself\./,/return "\$monitor_rc"/p' \
+    "$RELAY" > "$TMP/loop.sh"
+
+if [[ ! -s "$TMP/loop.sh" ]]; then
+    bad "could not locate the read loop in camera-relay"
+    echo; echo "  $PASS passed, $FAIL failed"; exit 1
+fi
+ok "read loop extracted from the script"
+
+# Run the extracted loop against a stub monitor that emits the usual events and
+# then exits with a chosen status.
+run_loop() {
+    local want_rc="$1"
+    cat > "$TMP/stub" <<STUB
+#!/usr/bin/env bash
+echo READY
+echo START
+echo STOP
+exit $want_rc
+STUB
+    chmod +x "$TMP/stub"
+
+    (
+        set -uo pipefail
+        info() { :; }
+        warn() { :; }
+        MONITOR_BIN="$TMP/stub"
+        loopback_dev=/dev/null
+        gst_log=/dev/null
+        STATE_CACHE="$TMP/state"
+        gst_cmd=(/bin/true)
+        run_it() {
+            # shellcheck disable=SC1090
+            source "$TMP/loop.sh"
+        }
+        run_it
+    )
+}
+
+run_loop 0 >/dev/null 2>&1
+rc=$?
+[[ $rc -eq 0 ]] && ok "monitor exiting 0 keeps the function at 0" \
+                || bad "monitor exiting 0 produced $rc"
+
+run_loop 42 >/dev/null 2>&1
+rc=$?
+if [[ $rc -eq 42 ]]; then
+    ok "monitor exiting 42 reaches the caller (Restart=on-failure can fire)"
+elif [[ $rc -eq 0 ]]; then
+    bad "monitor exit status was swallowed — the process substitution hides it"
+else
+    bad "expected 42, got $rc"
+fi
+
+# The whole point is that the status keeps going up the call chain, so the
+# dispatcher must not flatten it with a bare `cmd_start_on_demand; return 0`.
+if sed -n '/^cmd_start()/,/^}/p' "$RELAY" | grep -qE 'cmd_start_on_demand\s*$'; then
+    if sed -n '/^cmd_start()/,/^}/p' "$RELAY" | grep -qE '^\s*return\s*$'; then
+        ok "cmd_start returns the on-demand status unchanged"
+    else
+        bad "cmd_start does not propagate the on-demand status"
+    fi
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/camera-relay/tests/test-monitor-exit-propagation.sh
+++ b/camera-relay/tests/test-monitor-exit-propagation.sh
@@ -58,7 +58,11 @@ STUB
     chmod +x "$TMP/stub"
 
     (
-        set -uo pipefail
+        # Must match camera-relay's own `set -euo pipefail`. With -e missing,
+        # the subshell inside the process substitution survives a failing
+        # monitor and the sentinel gets emitted either way — so the test would
+        # pass against a script that is broken in production.
+        set -euo pipefail
         info() { :; }
         warn() { :; }
         MONITOR_BIN="$TMP/stub"
@@ -87,6 +91,34 @@ elif [[ $rc -eq 0 ]]; then
     bad "monitor exit status was swallowed — the process substitution hides it"
 else
     bad "expected 42, got $rc"
+fi
+
+# The EXIT trap gets the last word on the exit status. Under set -e a command
+# failing inside it replaces whatever the shell was exiting with — and
+# cleanup_on_demand's pkill exits 1 whenever there are no children left, which
+# is the normal case. That flattened every status to 1, sentinel or not.
+sed -n '/cleanup_on_demand() {/,/^    }/p' "$RELAY" > "$TMP/cleanup.sh"
+if [[ ! -s "$TMP/cleanup.sh" ]]; then
+    bad "could not locate cleanup_on_demand"
+else
+    # Run it as its own shell, not a subshell: $$ does not change inside a
+    # subshell, so `pkill -P $$` would target this test's children and take the
+    # harness down with it.
+    {
+        echo 'set -euo pipefail'
+        echo "PID_FILE=\"$TMP/pid\"; STATE_CACHE=\"$TMP/state\""
+        sed 's/^    //' "$TMP/cleanup.sh"
+        echo 'trap cleanup_on_demand EXIT'
+        echo 'f() { return 42; }'
+        echo 'f'
+    } > "$TMP/trap-case.sh"
+    bash "$TMP/trap-case.sh" >/dev/null 2>&1
+    rc=$?
+    if [[ $rc -eq 42 ]]; then
+        ok "the EXIT trap leaves the exit status alone"
+    else
+        bad "the EXIT trap rewrote the exit status to $rc"
+    fi
 fi
 
 # The whole point is that the status keeps going up the call chain, so the

--- a/camera-relay/tests/test-writer-format-check.sh
+++ b/camera-relay/tests/test-writer-format-check.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+# The monitor writes fixed-size YUYV frames straight into the loopback. If the
+# device is on any other format or geometry those writes are garbage to every
+# reader — and nothing says so: the device stays open, the relay still reports
+# "streaming", and the only trace used to be a warning in a log the next restart
+# truncates.
+#
+# That is reachable in practice. The loopback advertises only the writer's
+# format while a writer holds it; with no writer it offers every format it can
+# carry (58 of them here) and a reader picks whichever it likes.
+#
+# These tests check that open_writer() refuses to run in that state instead of
+# streaming into the void.
+#
+# Usage: ./test-writer-format-check.sh
+# Needs a v4l2loopback device to talk to; skips cleanly without one, and never
+# touches a loopback that a running relay is already driving.
+
+set -uo pipefail
+
+SRC="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay-monitor.c"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+skip() { echo "  – skipped: $*"; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-writer-format-check ($SRC)"
+
+if ! command -v gcc >/dev/null 2>&1; then
+    skip "gcc not available"
+    exit 0
+fi
+if ! gcc -O2 -Wall -Wextra -o "$TMP/monitor" "$SRC" 2>"$TMP/build.log"; then
+    echo "  ✗ build failed:"
+    sed 's/^/      /' "$TMP/build.log"
+    exit 1
+fi
+ok "builds clean with -Wall -Wextra"
+
+# Find a loopback nobody is driving. A relay holding one would be disrupted by
+# opening it as a second writer, and its format would not be ours to change.
+LOOPBACK=""
+for dev in /sys/devices/virtual/video4linux/video*; do
+    [[ -e "$dev/name" ]] || continue
+    node="/dev/$(basename "$dev")"
+    if pgrep -f "camera-relay-monitor $node" >/dev/null 2>&1; then
+        continue
+    fi
+    LOOPBACK="$node"
+    break
+done
+
+if [[ -z "$LOOPBACK" ]]; then
+    skip "no idle v4l2loopback device to test against"
+    echo
+    echo "  $PASS passed, $FAIL failed"
+    [[ $FAIL -eq 0 ]]
+    exit
+fi
+
+echo "  using $LOOPBACK"
+
+# A width past the device's max makes the driver report back something other
+# than what it was asked for — the same shape of mismatch a foreign format
+# produces, without needing to wrestle a second client onto the device.
+MAXW=$(cat /sys/module/v4l2loopback/parameters/max_width 2>/dev/null || echo 8192)
+out=$(timeout 10 "$TMP/monitor" "$LOOPBACK" $((MAXW + 1000)) 1080 -- /bin/true 2>&1)
+rc=$?
+
+if [[ $rc -eq 0 ]]; then
+    bad "accepted a geometry the device cannot provide"
+elif [[ "$out" != *"stayed on"* ]]; then
+    bad "refused, but without saying what the device is actually on: $out"
+else
+    ok "refuses when the device reports back a different format"
+    grep -q "garbage to every" <<<"$out" \
+        && ok "explains why it stops rather than streaming" \
+        || bad "message does not explain the consequence"
+fi
+
+# And the normal case still works, so the check is not simply always-on.
+out=$(timeout 6 "$TMP/monitor" "$LOOPBACK" 1920 1080 -- /bin/true 2>&1)
+if grep -q "Watching $LOOPBACK" <<<"$out"; then
+    ok "still starts normally on a format the device accepts"
+else
+    bad "rejected a valid 1920x1080 YUYV setup: $out"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]


### PR DESCRIPTION
`open_writer()` asks the loopback for 1920x1080 YUYV and then carries on regardless of the answer:

```c
if (xioctl(fd, VIDIOC_S_FMT, &fmt) < 0)
        fprintf(stderr, "[monitor] S_FMT warning: %s\n", strerror(errno));
```

Two ways that goes wrong. The ioctl can fail outright — and it can *succeed after adjusting what it was given*, since V4L2 reports the result back in the same struct, so a zero return is not confirmation.

Either way the monitor then writes fixed-size YUYV frames into a device on some other format, which is garbage to every reader. Nothing surfaces it: the device stays open, `camera-relay status` still says `STREAMING`, apps show a black picture, and the one warning lands in a log the next restart truncates.

## Why this is reachable

The loopback advertises only the writer's format while a writer holds it. With no writer it offers everything it can carry, and any reader may select one. On a Book4:

```
$ v4l2-ctl -d /dev/video0 --list-formats     # relay writing
        [0]: 'YUYV' (YUYV 4:2:2)

$ systemctl --user stop camera-relay.service
$ v4l2-ctl -d /dev/video0 --list-formats     # no writer
        [0]: 'BGR4' … [41]: 'MJPG' … [57]: 'HEVC'     # 58 of them

$ v4l2-ctl -d /dev/video0 --set-fmt-video=pixelformat=MJPG
$ v4l2-ctl -d /dev/video0 --get-fmt-video
        Pixel Format      : 'MJPG' (Motion-JPEG)
```

So a client that outlives the relay can leave the device somewhere else.

To be straight about the provenance: I hit a black-picture incident that looked exactly like this and could **not** reproduce it afterwards — the relay reclaims YUYV even with a reader attached, streaming or not. So this is not a fix for a confirmed field failure. It is a silent-failure path found while chasing one, and the cost of hitting it is an hour of debugging with no signal pointing anywhere.

## The change

`open_writer()` now fails on both, naming what the device is actually on and why it stopped:

```
[monitor] /dev/video0 stayed on 8192x1080 YUYV after asking for 9000x1080 YUYV.
[monitor] Fixed-size YUYV frames written to it would be garbage to every
[monitor] reader, so the relay stops here rather than stream silently. If an
[monitor] application is holding the device with its own format, closing it
[monitor] lets the relay recover on the next start.
```

Both call sites already handle a negative return, and the unit carries `Restart=on-failure` with `RestartSec=5` — so the relay retries and recovers on its own once whatever held the device lets go, rather than sitting there streaming into the void.

## Tests

`tests/test-writer-format-check.sh`. Triggering a mismatch needs only a geometry past the device's `max_width`, which produces the same shape of disagreement as a foreign format without having to wrestle a second client onto the device. It skips when no idle loopback is available and never touches one a running relay is driving — verified both ways:

```
with the relay running:   – skipped: no idle v4l2loopback device to test against
with it stopped:          4 passed, 0 failed
```

Verified on a Book4 Ultra: mismatch refused, normal 1920x1080 YUYV setup unaffected, relay still reports a real picture. Existing suites unchanged — gst-tools 10/0, egl-vendor-pin 17/0, relay-loop-bench PASS.

Independent of #78; touches only `camera-relay-monitor.c` and adds one test file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
