### PR TITLE
webcam-fix-libcamera: two bugs the uninstall/reinstall cycle exposed

### DIFF
--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1131,6 +1131,30 @@ if ! verify_libcamerasrc; then
     exit 1
 fi
 
+# Whoever put a libcamera under /usr/local, the linker has to prefer it — the
+# source build above writes this file, but that branch is skipped when a good
+# enough libcamera is already installed. uninstall.sh removes the file
+# unconditionally, so an uninstall/reinstall cycle used to drop /usr/local out
+# of the search path and leave the *system* libcamera winning.
+#
+# Nothing breaks at that moment, because the ldconfig cache still holds the old
+# entries. It breaks at the next unrelated `ldconfig` — a package upgrade,
+# another installer — and then camera-relay-gst, which deliberately does not
+# propagate LD_LIBRARY_PATH, silently loads the unpatched build.
+if compgen -G "/usr/local/lib*/libcamera.so.*" > /dev/null \
+   || compgen -G "/usr/local/lib/*/libcamera.so.*" > /dev/null; then
+    if [[ ! -f /etc/ld.so.conf.d/libcamera-local.conf ]]; then
+        sudo tee /etc/ld.so.conf.d/libcamera-local.conf > /dev/null << 'EOF'
+/usr/local/lib
+/usr/local/lib64
+/usr/local/lib/x86_64-linux-gnu
+/usr/local/lib/aarch64-linux-gnu
+EOF
+        sudo ldconfig
+        echo "  ✓ Restored /usr/local to the dynamic linker search path"
+    fi
+fi
+
 # ──────────────────────────────────────────────
 # [10/14] Install PipeWire libcamera plugin
 # ──────────────────────────────────────────────

--- a/webcam-fix-libcamera/uninstall.sh
+++ b/webcam-fix-libcamera/uninstall.sh
@@ -32,7 +32,34 @@ sudo rm -f /etc/udev/rules.d/72-camera-relay-mc-nodes.rules \
            /etc/udev/rules.d/90-camera-relay-mc-nodes.rules
 sudo udevadm control --reload-rules 2>/dev/null || true
 sudo udevadm trigger --action=change --subsystem-match=video4linux 2>/dev/null || true
-echo "  ✓ Raw nodes back to their default ownership"
+sudo udevadm settle 2>/dev/null || true
+
+# The trigger above is not enough on its own. It re-runs the rules — the
+# properties and the uaccess tag come back — but udev does not re-apply node
+# ownership on a change event, so every node keeps the camera-relay GID. With
+# the group deleted further down that leaves a dangling numeric GID, and if
+# that number is ever reused the nodes silently become reachable again.
+#
+# So restore the group explicitly rather than hoping udev does it. Nodes are
+# matched by GID, not by name, so this also repairs a system left dangling by
+# an earlier run of this script.
+_cr_gid=$(getent group camera-relay 2>/dev/null | cut -d: -f3)
+_restored=0
+for _v in /dev/video*; do
+    [[ -e "$_v" ]] || continue
+    _gid=$(stat -c%g "$_v" 2>/dev/null) || continue
+    # Either still owned by camera-relay, or owned by a GID that no longer
+    # resolves — both mean this script is what put it there.
+    if [[ -n "$_cr_gid" && "$_gid" == "$_cr_gid" ]] \
+       || ! getent group "$_gid" >/dev/null 2>&1; then
+        sudo chgrp video "$_v" 2>/dev/null && _restored=$((_restored + 1)) || true
+    fi
+done
+if (( _restored > 0 )); then
+    echo "  ✓ Raw nodes back to the 'video' group ($_restored restored)"
+else
+    echo "  ✓ Raw nodes already at their default ownership"
+fi
 
 # [1/8] Stop and remove camera relay
 echo "[1/8] Removing camera relay..."
@@ -144,8 +171,22 @@ sudo rm -f /usr/local/lib/udev/camera-relay-v4l2-io-mc
 sudo rm -f /usr/local/lib/sysusers.d/camera-relay.conf
 sudo udevadm control --reload-rules 2>/dev/null || true
 sudo udevadm trigger --action=change --subsystem-match=video4linux 2>/dev/null || true
+# Only drop the group once nothing references it. Deleting it while a device
+# node still carries its GID is what leaves the dangling numeric owner that
+# step 0 exists to prevent.
 if getent group camera-relay >/dev/null 2>&1; then
-    sudo groupdel camera-relay 2>/dev/null || true
+    _cr_gid=$(getent group camera-relay | cut -d: -f3)
+    _still=0
+    for _v in /dev/video*; do
+        [[ -e "$_v" ]] || continue
+        [[ "$(stat -c%g "$_v" 2>/dev/null)" == "$_cr_gid" ]] && _still=$((_still + 1)) || true
+    done
+    if (( _still > 0 )); then
+        echo "  ⚠ $_still device node(s) still owned by 'camera-relay' — keeping the"
+        echo "    group so their owner keeps resolving. Reboot and re-run to clear it."
+    else
+        sudo groupdel camera-relay 2>/dev/null || true
+    fi
 fi
 echo "  ✓ Udev rules removed"
 


### PR DESCRIPTION
You asked in #78 for `uninstall.sh` to be exercised rather than just reordered. It was, end to end, followed by a clean `install.sh`. Both scripts completed successfully and both left something broken.

## 1. The uninstaller never restored node ownership

The reorder in #78 was correct about *when* to revert, but relied on a udev behaviour that does not exist. Removing the rule and triggering `change` re-runs the rules — properties and the `uaccess` tag come back — but **udev does not re-apply node ownership on a change event**. `50-udev-default.rules` sets `GROUP="video"` unconditionally for `video4linux`, and the nodes still kept the `camera-relay` GID. `udevadm settle` makes no difference; it is not a reload race.

The uninstaller then deleted the group, so all 48 nodes ended up owned by a GID that no longer resolves:

```
/dev/video1  -> root:UNKNOWN (gid 974)
nodes with unresolvable gid: 48
```

Worse than cosmetic: if 974 is ever reused, those nodes silently become reachable by whatever group gets it. And nothing looks wrong at the time — the `uaccess` ACL returns once the rule is gone, so the camera keeps working.

Ownership is now restored explicitly instead of delegated to udev, matched by GID rather than by name so the same code repairs a system already left dangling. `groupdel` is guarded on no node still referencing the group. Verified on the machine that was in exactly that state:

```
[0/8] Restoring raw camera node ownership...
  ✓ Raw nodes back to the 'video' group (48 restored)

/dev/video1 -> root:video (gid 44)
nodes with unresolvable gid: 0
```

## 2. Reinstalling drops /usr/local from the linker path

`/etc/ld.so.conf.d/libcamera-local.conf` is written inside the source-build branch, which is skipped whenever an adequate libcamera is already installed. `uninstall.sh` removes it unconditionally. So uninstall → install leaves it gone.

The failure is delayed, which is what makes it worth fixing rather than shrugging at. The ldconfig cache still holds the old entries, so `ldconfig -p` looks right and everything works. It breaks at the next unrelated `ldconfig` — a package upgrade, another installer — after which the **system** libcamera wins. `camera-relay-gst` deliberately does not propagate `LD_LIBRARY_PATH`, precisely because it is setgid, so it would load the unpatched build with nothing pointing at the cause.

Now written whenever a libcamera exists under `/usr/local`, regardless of who installed it.

## Cycle result

Full state diff, before the uninstall versus after the reinstall, is now identical except for `v4l2loopback` not being loaded in the session — the module config is in place and it loads at boot.

Neither bug reproduces from either script alone, and neither is visible in review: in both cases the broken state looks healthy from the outside. #78 closed the ordering hole; running the thing is what found what was behind it.

## Unrelated, but surfaced by the same run

Both scripts restart PipeWire (`install.sh` step 14, `uninstall.sh` step 8). Any app playing audio loses its stream, which presents to the user as "the camera fix broke my speakers" — that is the conclusion I reached here before checking. Worth its own issue; I have not touched it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
