### PR TITLE
camera-relay: make Chromium-family browsers actually see the camera

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,13 @@ curl -sL https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/archive/
 
 To uninstall: `./uninstall.sh && sudo reboot`
 
-The webcam works with **Firefox, Chromium, Zoom, Teams, OBS, mpv, VLC**, and most other apps. For Chromium-based browsers (Brave, Chrome), the installer automatically enables the PipeWire camera flag.
+The webcam works with **Firefox, Chromium, Zoom, Teams, OBS, mpv, VLC**, and most other apps. Chromium-based browsers (Chrome, Brave) cannot see the camera relay over V4L2 and need the PipeWire camera flag; the installer sets it for you when the browser is closed during install and libcamera is 0.7+.
 
 ### Webcam Fix (built-in camera not detected) — Lunar Lake / Galaxy Book5 / Arch, Fedora & Ubuntu
 
 > Confirmed working on Samsung Galaxy Book5 Pro 940XHA (Fedora 43), 960XHA (Ubuntu 24.04), Dell XPS 13 9350 (Arch), and Lenovo X1 Carbon Gen13 (Fedora). See the [full README](webcam-fix-book5/) for details, known issues, and tested hardware.
 
-> **Requires kernel 6.18+** and **Arch, Fedora, or Ubuntu** (Ubuntu requires libcamera 0.5.2+ and kernel 6.18+ built from source). Includes an on-demand camera relay for non-PipeWire apps (Zoom, OBS, VLC) with near-zero idle CPU usage. For Chromium-based browsers (Brave, Chrome), the installer automatically enables the PipeWire camera flag.
+> **Requires kernel 6.18+** and **Arch, Fedora, or Ubuntu** (Ubuntu requires libcamera 0.5.2+ and kernel 6.18+ built from source). Includes an on-demand camera relay for non-PipeWire apps (Zoom, OBS, VLC) with near-zero idle CPU usage. Chromium-based browsers (Chrome, Brave) cannot see that relay over V4L2 and need the PipeWire camera flag; the installer sets it for you when the browser is closed during install and libcamera is 0.7+.
 
 > **OV02E10 purple tint fix:** Samsung Book5 models with the OV02E10 sensor mounted upside-down get purple/magenta tint due to a bayer pattern mismatch after the rotation flip. A patched libcamera build fixes this — see [OV02E10 bayer fix](webcam-fix-book5/libcamera-bayer-fix/) and the [webcam-fix-book5 README](webcam-fix-book5/) for details.
 
@@ -130,7 +130,7 @@ The built-in webcam uses Intel IPU6 (Meteor Lake or Raptor Lake) with an OmniVis
 
 - PipeWire-native apps (Firefox, Chromium) access the camera directly — no relay needed
 - Non-PipeWire apps use the on-demand V4L2 relay: near-zero CPU when idle, camera activates only when an app opens the device
-- Chromium browser PipeWire camera flags are auto-enabled during install
+- Chromium-family browsers are filtered out of the relay's V4L2 node by their own capability check, so the installer enables the PipeWire camera flag for them (browser must be closed; libcamera 0.7+)
 
 > **Multi-distro:** Supports **Ubuntu, Fedora, and Arch-based distros**. The install script auto-detects your distro. Galaxy Book5 (Lunar Lake / IPU7) is not supported (different driver stack) — see [webcam-fix-book5](webcam-fix-book5/).
 
@@ -140,7 +140,7 @@ For Galaxy Book5 (Lunar Lake / IPU7) on Arch, Fedora, and Ubuntu (source build).
 
 - PipeWire-native apps (Firefox, Chromium) access the camera directly
 - Non-PipeWire apps (Zoom, OBS, VLC) use the on-demand V4L2 relay: near-zero CPU when idle, camera activates only when an app opens the device
-- Chromium browser PipeWire camera flags are auto-enabled during install
+- Chromium-family browsers are filtered out of the relay's V4L2 node by their own capability check, so the installer enables the PipeWire camera flag for them (browser must be closed; libcamera 0.7+)
 
 For Samsung Book5 models with the OV02E10 sensor, an additional [patched libcamera build](webcam-fix-book5/libcamera-bayer-fix/) is needed to fix the purple/magenta tint caused by bayer pattern mismatch after rotation flip. See the [webcam-fix-book5 README](webcam-fix-book5/) for details.
 

--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -634,13 +634,149 @@ stop_pipeline() {
     fi
 }
 
-# No longer needed: with exclusive_caps=0, v4l2loopback always has
-# VIDEO_CAPTURE, so WirePlumber discovers it correctly on its own.
-# The old nudge_wireplumber (udevadm trigger + WirePlumber restart) was
-# needed for exclusive_caps=1 where caps only flipped after the relay
-# opened the device for writing. Removed because:
-# 1. sudo prompt blocks/confuses users
-# 2. WirePlumber restart disrupts active camera streams (causes flip)
+# nudge_wireplumber — make WirePlumber re-read the loopback's formats.
+#
+# This was removed once, on the grounds that exclusive_caps=0 always advertises
+# VIDEO_CAPTURE so WirePlumber classifies the node correctly on its own. That
+# part is true. What it missed is that *capabilities* are not the only thing
+# WirePlumber reads once and caches — the format list is too.
+#
+# v4l2loopback is loaded at boot from modules-load.d with no producer, so it
+# advertises its generic catch-all format set: BGRx/xRGB/BGR at any size from
+# 2x1 to 8192x8192, expressed as a Choice:Range. The relay's monitor only pins
+# YUYV 1920x1080 when it starts, at login — and camera-relay.service is
+# ordered After=wireplumber.service, so WirePlumber has already probed the
+# unconfigured device and will never look again.
+#
+# Firefox never noticed: it reads /dev/video0 directly. WebRTC's PipeWire camera
+# path (Chrome, Brave, Electron) parses SPA_PARAM_EnumFormat and needs a
+# discrete rectangle — a Choice:Range yields no parseable resolution, so the
+# node arrives with zero capabilities. Chrome logs "Found Camera: Camera Relay
+# (V4L2)" and then offers no device at all, which reads exactly like the camera
+# being missing.
+#
+# There is no lighter re-probe: the V4L2 monitor is udev-driven, nodes are built
+# at discovery, and WirePlumber exposes no "re-probe this device" call. Restart
+# is the documented answer — see "device.capabilities is read-only in PipeWire"
+# in webcam-fix/README.md, and the ExecStartPost the legacy v4l2-relayd fix uses.
+#
+# The two objections that got this removed do not apply to where it now runs:
+#   1. "sudo prompt blocks/confuses users" — that was udevadm trigger, needed
+#      because v4l2-relayd is a system service. camera-relay is a *user*
+#      service, so systemctl --user needs no privileges, and the restart alone
+#      is sufficient — the udev event was only ever about the caps flip.
+#   2. "restart disrupts active camera streams" — this runs from ExecStartPost
+#      at relay start, when by definition nothing is streaming yet.
+#
+# Conditional, so restarting the relay by hand does not cost an audio glitch
+# when the formats are already right.
+
+# The format the loopback really offers, as "<fourcc> <width>x<height>".
+#
+# Buffered into a variable first, then parsed from a here-string. Piping
+# v4l2-ctl into an awk that exits at the first match SIGPIPEs the writer, and
+# under `set -o pipefail` that surfaces as rc=141 — which reads as "no format"
+# and silently disables the whole check.
+loopback_real_format() {
+    local dev="$1" out
+    command -v v4l2-ctl &>/dev/null || return 1
+    out=$(v4l2-ctl -d "$dev" --list-formats-ext 2>/dev/null) || return 1
+    awk '
+        /^\t\[[0-9]+\]:/ { if (fmt == "") { fmt = $2; gsub(/'"'"'/, "", fmt) } }
+        /Size: Discrete/ { if (!done) { print fmt, $3; done = 1 } }
+    ' <<< "$out"
+}
+
+# Global id of the PipeWire node backing this loopback, if any.
+pipewire_node_for() {
+    local dev="$1"
+    command -v pw-dump &>/dev/null || return 1
+    command -v python3 &>/dev/null || return 1
+    pw-dump 2>/dev/null | python3 -c '
+import json, sys
+want = sys.argv[1]
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(0)
+for obj in data:
+    props = (obj.get("info") or {}).get("props") or {}
+    if props.get("media.class") == "Video/Source" and props.get("api.v4l2.path") == want:
+        print(obj["id"])
+        break
+' "$dev" 2>/dev/null
+}
+
+nudge_wireplumber() {
+    local dev="$1"
+    command -v systemctl &>/dev/null || return 0
+    command -v pw-cli &>/dev/null || return 0
+
+    local real node advertised
+    real=$(loopback_real_format "$dev") || return 0
+    [[ -n "$real" ]] || return 0
+
+    node=$(pipewire_node_for "$dev") || return 0
+    if [[ -z "$node" ]]; then
+        # No node yet — WirePlumber has not seen the device at all. A restart
+        # would not conjure one; leave it alone.
+        return 0
+    fi
+
+    # Same buffering rule as loopback_real_format: no `head` on a live pipe.
+    local params
+    params=$(pw-cli enum-params "$node" EnumFormat 2>/dev/null) || params=""
+    advertised=$(awk '/Rectangle/ { print $2; exit }' <<< "$params")
+
+    # Reading nothing is not evidence of a mismatch. Treating it as one would
+    # restart WirePlumber on every single relay start on any machine whose
+    # pw-cli output we cannot parse — an audio glitch per boot, forever, for a
+    # problem we have not established exists.
+    local want="${real##* }"
+    if [[ -z "$advertised" ]]; then
+        info "Could not read PipeWire's format for $dev — leaving WirePlumber alone"
+        return 0
+    fi
+
+    # A discrete rectangle matching the device means WirePlumber probed after
+    # the monitor pinned the format. Anything else — a range, or a stale
+    # resolution — means it probed too early.
+    if [[ "$advertised" == "$want" ]]; then
+        info "WirePlumber already sees $want — no re-probe needed"
+        return 0
+    fi
+
+    info "WirePlumber has stale formats for $dev (sees ${advertised:-none}, device offers $want)"
+    info "Restarting WirePlumber so PipeWire-based apps (Chrome, Brave) see a usable camera"
+    # --no-block: this unit is ordered After=wireplumber.service, so waiting on
+    # a wireplumber job from inside our own ExecStartPost can deadlock.
+    systemctl --user restart --no-block wireplumber 2>/dev/null || true
+}
+
+cmd_nudge_wireplumber() {
+    local dev
+    dev=$(detect_loopback_device 2>/dev/null) || return 0
+
+    # The unit is Type=simple, so systemd runs ExecStartPost as soon as
+    # ExecStart *forks* — well before the monitor has pinned YUYV on the
+    # loopback. Comparing at that moment reads no discrete format at all, which
+    # this function cannot distinguish from "nothing to do", so it would return
+    # silently and the stale node would survive the whole session. Wait for the
+    # monitor, bounded, then compare. (The legacy v4l2-relayd fix papered over
+    # the same race with a flat `sleep 2`.)
+    local waited=0
+    while [[ -z "$(loopback_real_format "$dev")" ]] && (( waited < 15 )); do
+        sleep 1
+        waited=$((waited + 1))
+    done
+
+    if [[ -z "$(loopback_real_format "$dev")" ]]; then
+        info "Loopback reported no format after ${waited}s — skipping WirePlumber check"
+        return 0
+    fi
+
+    nudge_wireplumber "$dev"
+}
 
 # ── Commands ─────────────────────────────────────────────────────────────────
 
@@ -1266,14 +1402,146 @@ cmd_doctor() {
             echo "  $b: $bpath"
         fi
     done
+
+    # Whether Chromium can see the loopback is not a matter of opinion: it
+    # applies a fixed capability test in
+    # media/capture/video/linux/video_capture_device_factory_v4l2.cc —
+    #
+    #   (capabilities & VIDEO_CAPTURE && !(capabilities & VIDEO_OUTPUT)) ||
+    #   (capabilities & DEVICE_CAPS &&
+    #    device_caps  & VIDEO_CAPTURE && !(device_caps  & VIDEO_OUTPUT))
+    #
+    # so we can evaluate the same expression here rather than guess. Under
+    # exclusive_caps=0 the relay reports both CAPTURE and OUTPUT, every branch
+    # fails, and the node is filtered out before any permission prompt —
+    # enumerateDevices() simply returns no videoinput. Firefox accepts dual caps
+    # and reads the node directly, which is the whole reason the two disagree.
+    if $chromium_family && [[ -n "$dev" ]] && command -v v4l2-ctl &>/dev/null; then
+        local caps_hex devcaps_hex info visible=1
+        info=$(v4l2-ctl -d "$dev" --info 2>/dev/null) || info=""
+        caps_hex=$(awk '/^\tCapabilities/ { print $3; exit }' <<< "$info")
+        devcaps_hex=$(awk '/^\tDevice Caps/ { print $4; exit }' <<< "$info")
+        if [[ -n "$caps_hex" ]]; then
+            local caps=$((caps_hex)) devcaps=0
+            [[ -n "$devcaps_hex" ]] && devcaps=$((devcaps_hex))
+            if (( (caps & 0x1) && !(caps & 0x2) )); then
+                visible=0
+            elif (( (caps & 0x80000000) && (devcaps & 0x1) && !(devcaps & 0x2) )); then
+                visible=0
+            fi
+            echo
+            if (( visible == 0 )); then
+                echo "  Direct V4L2: the relay node passes Chromium's capability test."
+            else
+                echo "  Direct V4L2: Chromium CANNOT see $dev."
+                echo "    It reports VIDEO_CAPTURE and VIDEO_OUTPUT together"
+                echo "    (caps $caps_hex, device caps ${devcaps_hex:-n/a}), and Chromium"
+                echo "    only accepts a node that reports capture WITHOUT output."
+                echo "    This is expected under exclusive_caps=0 and affects Chrome,"
+                echo "    Chromium, Brave, Edge and every Electron app. Firefox is fine."
+                echo "    → those browsers need the PipeWire path below instead."
+            fi
+        fi
+    fi
+
+    # The PipeWire path is the way out, so report whether it is actually usable
+    # rather than telling the user to flip a flag and hope.
     if $chromium_family; then
-        # The relay node carries both CAPTURE and OUTPUT caps under
-        # exclusive_caps=0; Firefox accepts that and reads it over V4L2, while
-        # Chromium-family browsers often will not (issue #65).
-        echo "  If Firefox sees the camera but a Chromium-family browser does not:"
-        echo "    chrome://flags/#enable-webrtc-pipewire-camera -> Enabled, then fully"
-        echo "    restart the browser. Safe on libcamera 0.7+; leave it OFF on"
-        echo "    Ubuntu 24.04/Zorin (libcamera 0.2.0 has no IPU6 support)."
+        local pw_source=""
+        if command -v pw-dump &>/dev/null && command -v python3 &>/dev/null; then
+            pw_source=$(pw-dump 2>/dev/null | python3 -c '
+import json, sys
+try:
+    data = json.load(sys.stdin)
+except ValueError:
+    sys.exit(0)
+for obj in data:
+    props = (obj.get("info") or {}).get("props") or {}
+    if props.get("media.class") == "Video/Source":
+        print(props.get("node.description") or props.get("node.name") or "?")
+        break
+' 2>/dev/null) || pw_source=""
+        fi
+        if [[ -n "$pw_source" ]]; then
+            echo "  PipeWire camera source: $pw_source"
+        else
+            echo "  PipeWire camera source: NONE — the flag below has nothing to consume."
+        fi
+
+        # Existing is not the same as usable. WirePlumber probes the loopback at
+        # login, before the monitor pins its format, and caches v4l2loopback's
+        # catch-all range. WebRTC needs a discrete rectangle, so a node in that
+        # state produces a camera with no resolutions — Chrome finds it and
+        # offers nothing, which looks identical to no camera at all.
+        if [[ -n "$dev" ]]; then
+            local real_fmt pw_node pw_rect
+            real_fmt=$(loopback_real_format "$dev") || real_fmt=""
+            pw_node=$(pipewire_node_for "$dev") || pw_node=""
+            if [[ -n "$real_fmt" && -n "$pw_node" ]]; then
+                local params_out
+                params_out=$(pw-cli enum-params "$pw_node" EnumFormat 2>/dev/null) || params_out=""
+                pw_rect=$(awk '/Rectangle/ { print $2; exit }' <<< "$params_out")
+                if [[ -z "$pw_rect" ]]; then
+                    echo "  PipeWire format:        could not read (node $pw_node)"
+                elif [[ "$pw_rect" == "${real_fmt##* }" ]]; then
+                    echo "  PipeWire format:        $real_fmt — matches the device"
+                else
+                    echo "  PipeWire format:        STALE — PipeWire says $pw_rect, device offers ${real_fmt##* }"
+                    echo "    WirePlumber probed the loopback before the relay pinned its format,"
+                    echo "    so it cached v4l2loopback's catch-all range. WebRTC cannot parse a"
+                    echo "    range, so Chrome finds the camera and still offers no device."
+                    echo "    → fix with: camera-relay nudge-wireplumber"
+                fi
+            fi
+        fi
+
+        # Per profile, what the flag actually is. "Consider enabling it" is not
+        # a diagnostic; whether it is set is.
+        local prof label dir state needs_flag=0
+        for prof in \
+            "Chrome|$HOME/.config/google-chrome" \
+            "Chromium|$HOME/.config/chromium" \
+            "Chromium (snap)|$HOME/snap/chromium/current/.config/chromium" \
+            "Brave|$HOME/.config/BraveSoftware/Brave-Browser" \
+            "Vivaldi|$HOME/.config/vivaldi"; do
+            label=${prof%%|*}
+            dir=${prof#*|}
+            [[ -f "$dir/Local State" ]] || continue
+            if ! command -v python3 &>/dev/null; then
+                echo "  $label PipeWire flag: unknown (python3 not installed)"
+                continue
+            fi
+            state=$(python3 -c '
+import json, re, sys
+flag = "enable-webrtc-pipewire-camera"
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, ValueError):
+    print("unreadable")
+    sys.exit(0)
+browser = data.get("browser")
+labs = browser.get("enabled_labs_experiments") if isinstance(browser, dict) else None
+labs = labs if isinstance(labs, list) else []
+hit = [x for x in labs if isinstance(x, str) and re.match(r"^%s(@\d+)?$" % re.escape(flag), x)]
+print("DISABLED" if any(x.endswith("@2") for x in hit) else ("ENABLED" if hit else "not set"))
+' "$dir/Local State" 2>/dev/null) || state="unreadable"
+            echo "  $label PipeWire flag: $state"
+            [[ "$state" == "ENABLED" ]] || needs_flag=1
+        done
+
+        # Only explain the fix when something still needs it. A doctor that
+        # prints the same remedy whether or not it applies trains people to
+        # skim past it.
+        if (( needs_flag )); then
+            echo "    Set it with: camera-relay/chromium-pipewire-camera.sh"
+            echo "    or by hand at chrome://flags/#enable-webrtc-pipewire-camera,"
+            echo "    then fully quit and reopen the browser. Needs libcamera 0.7+"
+            echo "    (this machine: $(pkg-config --modversion libcamera 2>/dev/null || echo unknown));"
+            echo "    on Ubuntu 24.04/Zorin libcamera 0.2.0 has no IPU6 support and the"
+            echo "    flag makes things worse. Edge has no such flag and cannot be fixed"
+            echo "    this way."
+        fi
     fi
     if command -v flatpak &>/dev/null; then
         { flatpak list --app --columns=application 2>/dev/null \
@@ -1431,6 +1699,18 @@ After=pipewire.service wireplumber.service
 [Service]
 Type=simple
 ExecStart=/usr/local/bin/camera-relay start --on-demand
+# WirePlumber probed the loopback at login, before the monitor pinned its
+# format (this unit is After=wireplumber.service), so it cached v4l2loopback's
+# generic catch-all format range. WebRTC's PipeWire camera path cannot parse a
+# range and ends up with a camera that has no resolutions — Chrome finds the
+# node and still offers no device. Re-probe, but only when the formats really
+# do disagree. See nudge_wireplumber in this script.
+#
+# Leading '-': advisory. A camera that works for every V4L2 app is worth more
+# than this correction, so nothing here may take the relay down — including the
+# case where this unit was regenerated but /usr/local/bin/camera-relay is still
+# an older copy that does not know the subcommand.
+ExecStartPost=-/usr/local/bin/camera-relay nudge-wireplumber
 ExecStop=/usr/local/bin/camera-relay stop
 Restart=on-failure
 RestartSec=5
@@ -1498,6 +1778,7 @@ case "${1:-}" in
     stop)               cmd_stop ;;
     status)             cmd_status "${2:-}" ;;
     doctor)             cmd_doctor ;;
+    nudge-wireplumber)  cmd_nudge_wireplumber ;;
     enable-persistent)  cmd_enable_persistent "${2:-}" ;;
     disable-persistent) cmd_disable_persistent ;;
     -h|--help|help)     usage ;;

--- a/camera-relay/chromium-pipewire-camera.sh
+++ b/camera-relay/chromium-pipewire-camera.sh
@@ -1,0 +1,324 @@
+#!/usr/bin/env bash
+# chromium-pipewire-camera.sh — route Chromium-family browsers to the camera
+# through PipeWire instead of direct V4L2.
+#
+# Chromium cannot see the camera relay at all. Its V4L2 enumeration
+# (media/capture/video/linux/video_capture_device_factory_v4l2.cc) accepts a
+# node only when it reports VIDEO_CAPTURE *and not* VIDEO_OUTPUT:
+#
+#     (cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
+#      !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
+#     (cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
+#      cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
+#      !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
+#
+# The relay node is created with exclusive_caps=0, so it advertises both and
+# every branch of that condition fails. Firefox accepts dual caps and reads the
+# node directly, which is why it works and Chrome silently lists no camera —
+# enumerateDevices() returns zero videoinput entries, before any permission
+# prompt. Same filter in Edge and in every Electron app.
+#
+# exclusive_caps=1 would fix it at the source, but the relay deliberately moved
+# away from that (see the note above nudge_wireplumber in camera-relay): with
+# exclusive_caps=1 WirePlumber classifies the node as an output at boot and the
+# PipeWire path breaks instead. So we take the other route — WirePlumber already
+# publishes the relay as a Video/Source, and this flag makes Chromium consume it.
+#
+# This flag is necessary but NOT sufficient on its own. WirePlumber probes the
+# loopback at login, before the relay's monitor pins its format, and caches
+# v4l2loopback's catch-all range instead. WebRTC cannot parse a range, so Chrome
+# finds the camera and still offers no device — same NotFoundError, different
+# cause. nudge_wireplumber in camera-relay handles that half, from ExecStartPost.
+# If this script reports success and Chrome still sees nothing, check there and
+# in `camera-relay doctor` before suspecting the flag.
+#
+# Usage: ./chromium-pipewire-camera.sh [enable|disable|status] [--force]
+#
+#   enable    write the flag into every Chromium-family profile found (default)
+#   disable   take it back out (used by the uninstallers)
+#   status    report per profile, change nothing
+#
+#   --force   skip the libcamera version gate
+
+set -uo pipefail
+
+SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+FLAG="enable-webrtc-pipewire-camera"
+FLAG_ENTRY="${FLAG}@1"      # @1 = "Enabled"; @2 would be "Disabled"
+BACKUP_SUFFIX=".camera-relay.bak"
+
+ACTION="enable"
+FORCE=0
+for arg in "$@"; do
+    case "$arg" in
+        enable|disable|status) ACTION="$arg" ;;
+        --force)               FORCE=1 ;;
+        -h|--help)
+            sed -n '/^# Usage:/,/^$/p' "${BASH_SOURCE[0]}" | sed 's/^# \?//'
+            exit 0 ;;
+        *)
+            echo "ERROR: unknown argument: $arg" >&2
+            exit 2 ;;
+    esac
+done
+
+# ── libcamera version gate ───────────────────────────────────────────────────
+# On Ubuntu 24.04 / Zorin the system libcamera is 0.2.0, which has no IPU6
+# support: there the flag sends Chromium down a PipeWire path that cannot
+# produce frames. 0.7+ is where the PipeWire camera path actually works.
+version_ge() {
+    [[ "$(printf '%s\n%s\n' "$2" "$1" | LC_ALL=C sort -V | head -1)" == "$2" ]]
+}
+
+libcamera_version() {
+    command -v pkg-config >/dev/null 2>&1 || return 1
+    local v
+    v=$(pkg-config --modversion libcamera 2>/dev/null) || return 1
+    [[ -n "$v" ]] || return 1
+    printf '%s\n' "$v"
+}
+
+# ── Target user ──────────────────────────────────────────────────────────────
+# We are editing a browser profile, so this has to run as the desktop user even
+# when the installer was itself started with sudo. Same seat0 lookup the
+# installers already use to find the relay's user.
+resolve_target_user() {
+    if [[ $EUID -ne 0 ]]; then
+        id -un
+        return 0
+    fi
+    if [[ -n "${SUDO_USER:-}" && "$SUDO_USER" != "root" ]]; then
+        printf '%s\n' "$SUDO_USER"
+        return 0
+    fi
+    local u
+    u=$(loginctl list-sessions --no-legend 2>/dev/null \
+        | awk '$4 == "seat0" {print $3}' | head -1)
+    [[ -n "$u" && "$u" != "root" ]] || return 1
+    printf '%s\n' "$u"
+}
+
+# ── Profile discovery ────────────────────────────────────────────────────────
+# Emits "label<TAB>directory holding Local State" for every Chromium-family
+# profile that exists under $1. Absent ones are skipped without comment — most
+# machines have one of these, not five.
+#
+# Edge is deliberately absent: it ships no enable-webrtc-pipewire-camera flag,
+# so there is nothing to write. It stays blind to the relay.
+chromium_profile_dirs() {
+    local home="$1" d
+    local -a candidates=(
+        "Chrome|$home/.config/google-chrome"
+        "Chrome Beta|$home/.config/google-chrome-beta"
+        "Chrome Unstable|$home/.config/google-chrome-unstable"
+        "Chromium|$home/.config/chromium"
+        "Chromium (snap)|$home/snap/chromium/current/.config/chromium"
+        "Brave|$home/.config/BraveSoftware/Brave-Browser"
+        "Vivaldi|$home/.config/vivaldi"
+        "Chrome (flatpak)|$home/.var/app/com.google.Chrome/config/google-chrome"
+        "Chromium (flatpak)|$home/.var/app/org.chromium.Chromium/config/chromium"
+        "Brave (flatpak)|$home/.var/app/com.brave.Browser/config/BraveSoftware/Brave-Browser"
+    )
+    for d in "${candidates[@]}"; do
+        [[ -f "${d#*|}/Local State" ]] && printf '%s\t%s\n' "${d%%|*}" "${d#*|}"
+    done
+    return 0
+}
+
+# ── Running-browser guard ────────────────────────────────────────────────────
+# Chromium rewrites Local State from memory when it exits, so a write against a
+# live profile is silently discarded on quit. SingletonLock is the profile's own
+# "I am running" marker and points at host-pid, which beats matching process
+# names — those get truncated to 15 chars in comm and "chrome" appears in our
+# own argv besides.
+browser_running() {
+    local dir="$1" target pid
+    local lock="$dir/SingletonLock"
+    [[ -L "$lock" ]] || return 1
+    target=$(readlink "$lock" 2>/dev/null) || return 1
+    pid=${target##*-}
+    [[ "$pid" =~ ^[0-9]+$ ]] || return 1
+    kill -0 "$pid" 2>/dev/null       # stale lock after a crash → not running
+}
+
+# ── The edit ─────────────────────────────────────────────────────────────────
+# json.dump with compact separators is what Chromium itself writes, so the file
+# stays byte-comparable apart from our entry. Written to a temp file in the same
+# directory and os.replace'd, so a crash mid-write cannot truncate the profile.
+FLAG_PY='
+import json, os, re, sys
+
+path, flag, entry, action = sys.argv[1:5]
+pattern = re.compile(r"^" + re.escape(flag) + r"(@\d+)?$")
+
+try:
+    with open(path, encoding="utf-8") as fh:
+        data = json.load(fh)
+except (OSError, ValueError) as exc:
+    print("unreadable: %s" % exc, file=sys.stderr)
+    sys.exit(3)
+
+if not isinstance(data, dict):
+    print("unreadable: top level is not an object", file=sys.stderr)
+    sys.exit(3)
+
+browser = data.get("browser")
+if not isinstance(browser, dict):
+    browser = {}
+labs = browser.get("enabled_labs_experiments")
+if not isinstance(labs, list):
+    labs = []
+
+kept = [x for x in labs if not (isinstance(x, str) and pattern.match(x))]
+had = len(kept) != len(labs)
+
+if action == "status":
+    print("enabled" if entry in labs else ("other" if had else "absent"))
+    sys.exit(0)
+
+if action == "enable":
+    new = kept + [entry]
+    if new == labs:
+        print("unchanged")
+        sys.exit(0)
+elif action == "disable":
+    if not had:
+        print("unchanged")
+        sys.exit(0)
+    new = kept
+else:
+    print("unreadable: bad action", file=sys.stderr)
+    sys.exit(3)
+
+if new:
+    browser["enabled_labs_experiments"] = new
+else:
+    browser.pop("enabled_labs_experiments", None)
+
+if browser:
+    data["browser"] = browser
+
+tmp = path + ".camera-relay.tmp"
+try:
+    with open(tmp, "w", encoding="utf-8") as fh:
+        json.dump(data, fh, separators=(",", ":"), ensure_ascii=False)
+    os.replace(tmp, path)
+except OSError as exc:
+    try:
+        os.unlink(tmp)
+    except OSError:
+        pass
+    print("unwritable: %s" % exc, file=sys.stderr)
+    sys.exit(4)
+
+print("changed")
+'
+
+flag_state() {
+    python3 -c "$FLAG_PY" "$1/Local State" "$FLAG" "$FLAG_ENTRY" status 2>/dev/null
+}
+
+apply_flag() {
+    python3 -c "$FLAG_PY" "$1/Local State" "$FLAG" "$FLAG_ENTRY" "$2"
+}
+
+# ── Main ─────────────────────────────────────────────────────────────────────
+main() {
+    if ! command -v python3 >/dev/null 2>&1; then
+        echo "  ⚠ python3 not found — cannot edit browser profiles."
+        echo "    Set chrome://flags/#${FLAG} to Enabled by hand."
+        return 0
+    fi
+
+    local target_user target_home
+    if ! target_user=$(resolve_target_user); then
+        echo "  ⚠ Could not determine the desktop user — skipping browser setup."
+        return 0
+    fi
+    target_home=$(getent passwd "$target_user" | cut -d: -f6)
+    if [[ -z "$target_home" || ! -d "$target_home" ]]; then
+        echo "  ⚠ No home directory for '$target_user' — skipping browser setup."
+        return 0
+    fi
+
+    # Re-exec as the desktop user so every file we touch keeps their ownership.
+    if [[ $EUID -eq 0 ]]; then
+        exec sudo -u "$target_user" -- "$SELF" "$@"
+    fi
+
+    if [[ "$ACTION" == "enable" && $FORCE -eq 0 ]]; then
+        local ver
+        if ! ver=$(libcamera_version); then
+            echo "  – Skipping Chromium PipeWire camera flag: libcamera version unknown."
+            echo "    Enable it by hand once you know you are on 0.7+:"
+            echo "      chrome://flags/#${FLAG} → Enabled"
+            echo "    Or re-run with --force."
+            return 0
+        fi
+        if ! version_ge "$ver" "0.7"; then
+            echo "  – Skipping Chromium PipeWire camera flag: libcamera $ver has no IPU6/IPU7"
+            echo "    support, and the flag would send Chromium down that broken path."
+            return 0
+        fi
+    fi
+
+    local -a profiles=()
+    mapfile -t profiles < <(chromium_profile_dirs "$target_home")
+    if [[ ${#profiles[@]} -eq 0 ]]; then
+        echo "  – No Chromium-family browser profiles found (nothing to do)."
+        return 0
+    fi
+
+    local blocked=0 line label dir state out rc
+    for line in "${profiles[@]}"; do
+        label=${line%%$'\t'*}
+        dir=${line#*$'\t'}
+
+        if [[ "$ACTION" == "status" ]]; then
+            state=$(flag_state "$dir")
+            printf '  %-20s %s\n' "$label:" "${state:-unreadable}"
+            continue
+        fi
+
+        if browser_running "$dir"; then
+            echo "  ⚠ $label is running — not touching its profile."
+            echo "    It rewrites this file on exit and would discard the change."
+            blocked=1
+            continue
+        fi
+
+        # One backup per profile, taken before our first write. Never refreshed,
+        # so it stays the pre-camera-relay original rather than yesterday's copy.
+        [[ -f "$dir/Local State$BACKUP_SUFFIX" ]] || \
+            cp -p "$dir/Local State" "$dir/Local State$BACKUP_SUFFIX" 2>/dev/null || true
+
+        out=$(apply_flag "$dir" "$ACTION" 2>&1) && rc=0 || rc=$?
+        case "$rc:$out" in
+            0:changed)
+                if [[ "$ACTION" == "enable" ]]; then
+                    echo "  ✓ $label: PipeWire camera flag enabled"
+                else
+                    echo "  ✓ $label: PipeWire camera flag removed"
+                fi ;;
+            0:unchanged)
+                echo "  ✓ $label: already correct" ;;
+            *)
+                echo "  ⚠ $label: could not update profile (${out:-unknown error})" ;;
+        esac
+    done
+
+    if [[ "$ACTION" == "enable" ]]; then
+        if [[ $blocked -eq 1 ]]; then
+            echo
+            echo "  Quit the browser above completely, then re-run:"
+            echo "    $SELF"
+            echo "  Or set chrome://flags/#${FLAG} to Enabled by hand."
+        else
+            echo "  Restart any open Chromium-family browser for this to take effect."
+        fi
+    fi
+    return 0
+}
+
+main "$@"

--- a/camera-relay/tests/test-chromium-pipewire-flag.sh
+++ b/camera-relay/tests/test-chromium-pipewire-flag.sh
@@ -1,0 +1,400 @@
+#!/usr/bin/env bash
+# Regression tests for chromium-pipewire-camera.sh.
+#
+# Chromium filters the relay node out of V4L2 enumeration entirely — it accepts
+# a node only when it reports VIDEO_CAPTURE and *not* VIDEO_OUTPUT, and the relay
+# under exclusive_caps=0 reports both. The flag this script writes is what routes
+# those browsers through PipeWire instead, so it is the only thing standing
+# between Chrome and no camera at all.
+#
+# It edits a live browser profile, which makes three failure modes expensive:
+#   1. Clobbering Local State would take the user's whole browser config with it
+#      — every other key in that file has to survive untouched.
+#   2. Writing while the browser runs looks like it worked and is discarded on
+#      quit, so the guard has to hold even against a stale lock from a crash.
+#   3. Enabling it on libcamera 0.2.0 (Ubuntu 24.04 / Zorin) sends Chromium down
+#      a path with no IPU6 support, which is worse than leaving it alone.
+#
+# Every case runs the real script against a fake HOME with stubbed getent and
+# pkg-config.
+#
+# Usage: ./test-chromium-pipewire-flag.sh
+# Requires no camera hardware and no browser, and touches no system state.
+
+set -uo pipefail
+
+SCRIPT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/chromium-pipewire-camera.sh"
+FLAG_ENTRY="enable-webrtc-pipewire-camera@1"
+PASS=0
+FAIL=0
+
+ok()   { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad()  { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+skip() { echo "  – skipped: $*"; }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-chromium-pipewire-flag ($SCRIPT)"
+
+if ! command -v python3 >/dev/null 2>&1; then
+    skip "python3 not available"
+    echo
+    echo "  $PASS passed, $FAIL failed"
+    exit 0
+fi
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+# A fake home with stubbed getent/pkg-config on PATH. The script resolves the
+# profile directory through getent and the libcamera version through pkg-config,
+# so those two stubs are the whole isolation boundary.
+new_env() {
+    # ${1-} not ${1:-}: an explicitly empty version means "pkg-config is broken",
+    # which is a case under test, not a request for the default.
+    local libcamera_version="${1-0.7.2}"
+    local env_dir="$TMP/env-$RANDOM$RANDOM"
+    mkdir -p "$env_dir/home" "$env_dir/bin"
+
+    cat > "$env_dir/bin/getent" << EOF
+#!/bin/sh
+[ "\$1" = passwd ] || exit 2
+echo "\$2:x:1000:1000::$env_dir/home:/bin/bash"
+EOF
+
+    if [[ -n "$libcamera_version" ]]; then
+        cat > "$env_dir/bin/pkg-config" << EOF
+#!/bin/sh
+[ "\$1" = --modversion ] && [ "\$2" = libcamera ] || exit 1
+echo "$libcamera_version"
+EOF
+    else
+        # No pkg-config at all — the version is undeterminable.
+        printf '#!/bin/sh\nexit 127\n' > "$env_dir/bin/pkg-config"
+    fi
+
+    chmod +x "$env_dir/bin/getent" "$env_dir/bin/pkg-config"
+    printf '%s\n' "$env_dir"
+}
+
+# Writes a profile's Local State and returns its directory.
+make_profile() {
+    local env_dir="$1" rel="$2" json="$3"
+    local dir="$env_dir/home/$rel"
+    mkdir -p "$dir"
+    printf '%s' "$json" > "$dir/Local State"
+    printf '%s\n' "$dir"
+}
+
+run_script() {
+    local env_dir="$1"; shift
+    PATH="$env_dir/bin:$PATH" "$SCRIPT" "$@" 2>&1
+}
+
+# Reads back enabled_labs_experiments as a JSON array, or a marker.
+labs_of() {
+    python3 - "$1/Local State" << 'EOF'
+import json, sys
+try:
+    with open(sys.argv[1], encoding="utf-8") as fh:
+        data = json.load(fh)
+except Exception as exc:
+    print("UNPARSEABLE(%s)" % type(exc).__name__)
+    sys.exit(0)
+browser = data.get("browser")
+labs = browser.get("enabled_labs_experiments") if isinstance(browser, dict) else None
+if labs is None:
+    print("MISSING")
+else:
+    print(json.dumps(labs, separators=(",", ":")))
+EOF
+}
+
+# Everything except our one key, so we can assert the rest of the file survived.
+rest_of() {
+    python3 - "$1/Local State" << 'EOF'
+import json, sys
+with open(sys.argv[1], encoding="utf-8") as fh:
+    data = json.load(fh)
+browser = data.get("browser")
+if isinstance(browser, dict):
+    browser.pop("enabled_labs_experiments", None)
+    if not browser:
+        data.pop("browser", None)
+print(json.dumps(data, sort_keys=True))
+EOF
+}
+
+# ── 1. What lands in enabled_labs_experiments ────────────────────────────────
+# The array is shared with every other flag the user has set by hand, so this is
+# a merge, not an overwrite.
+echo
+echo "enable → resulting flag list"
+
+enable_case() {
+    local desc="$1" want="$2" json="$3"
+    local env_dir dir got
+    env_dir=$(new_env)
+    dir=$(make_profile "$env_dir" ".config/google-chrome" "$json")
+    run_script "$env_dir" enable > /dev/null
+    got=$(labs_of "$dir")
+    if [[ "$got" == "$want" ]]; then
+        ok "$(printf '%-34s %s' "$desc" "$want")"
+    else
+        bad "$(printf '%-34s expected %s, got %s' "$desc" "$want" "$got")"
+    fi
+}
+
+enable_case "no browser key"        "[\"$FLAG_ENTRY\"]" '{"foo":1}'
+enable_case "browser without labs"  "[\"$FLAG_ENTRY\"]" '{"browser":{"x":2}}'
+enable_case "empty labs array"      "[\"$FLAG_ENTRY\"]" '{"browser":{"enabled_labs_experiments":[]}}'
+enable_case "already enabled"       "[\"$FLAG_ENTRY\"]" "{\"browser\":{\"enabled_labs_experiments\":[\"$FLAG_ENTRY\"]}}"
+# Bare (no @suffix) also means enabled; normalising to @1 keeps one spelling.
+enable_case "bare, no @suffix"      "[\"$FLAG_ENTRY\"]" '{"browser":{"enabled_labs_experiments":["enable-webrtc-pipewire-camera"]}}'
+# @2 is "Disabled" — the user (or an older docs pass) turned it off explicitly.
+enable_case "explicitly disabled"   "[\"$FLAG_ENTRY\"]" '{"browser":{"enabled_labs_experiments":["enable-webrtc-pipewire-camera@2"]}}'
+# Other people's flags must survive, and in order.
+enable_case "alongside other flags" "[\"ozone-platform-hint@1\",\"vulkan\",\"$FLAG_ENTRY\"]" \
+    '{"browser":{"enabled_labs_experiments":["ozone-platform-hint@1","vulkan"]}}'
+# A flag that merely starts with the same name is a different flag.
+enable_case "similar flag name kept" "[\"enable-webrtc-pipewire-camera-v2\",\"$FLAG_ENTRY\"]" \
+    '{"browser":{"enabled_labs_experiments":["enable-webrtc-pipewire-camera-v2"]}}'
+
+# ── 2. The rest of the file ──────────────────────────────────────────────────
+# Local State holds profile names, update state, metrics ids. Losing any of it
+# to a flag edit would be a far worse bug than the camera it fixes.
+echo
+echo "everything else in Local State"
+
+env_dir=$(new_env)
+rich='{"browser":{"enabled_labs_experiments":["vulkan"],"window_placement":{"maximized":true}},"profile":{"info_cache":{"Default":{"name":"Trabalho — Ação"}}},"user_experience_metrics":{"stability":{"crash_count":3}},"os_crypt":{"encrypted_key":"AAAA"}}'
+dir=$(make_profile "$env_dir" ".config/google-chrome" "$rich")
+before=$(rest_of "$dir")
+run_script "$env_dir" enable > /dev/null
+after=$(rest_of "$dir")
+if [[ "$before" == "$after" ]]; then
+    ok "every other key preserved (incl. non-ASCII profile name)"
+else
+    bad "other keys changed:\n    before: $before\n    after:  $after"
+fi
+if [[ "$(labs_of "$dir")" == "[\"vulkan\",\"$FLAG_ENTRY\"]" ]]; then
+    ok "pre-existing flag kept alongside ours"
+else
+    bad "pre-existing flag lost: $(labs_of "$dir")"
+fi
+# Chromium writes compact JSON; matching it keeps the diff to our entry alone.
+if grep -q '", "' "$dir/Local State" || grep -q '": ' "$dir/Local State"; then
+    bad "output is pretty-printed — Chromium writes compact JSON"
+else
+    ok "output stays compact, the way Chromium writes it"
+fi
+
+# A byte-identical no-op on the second run: re-running the installer must not
+# churn the file.
+cp -p "$dir/Local State" "$TMP/idem-before"
+run_script "$env_dir" enable > /dev/null
+if cmp -s "$TMP/idem-before" "$dir/Local State"; then
+    ok "second run is byte-identical (idempotent)"
+else
+    bad "second run rewrote the file"
+fi
+
+# ── 3. Backup ────────────────────────────────────────────────────────────────
+# Taken once, before the first write. Refreshing it on every run would quietly
+# replace the pre-install original with an already-modified copy.
+echo
+echo "backup"
+
+if [[ -f "$dir/Local State.camera-relay.bak" ]]; then
+    ok "backup created"
+    if [[ "$(cat "$dir/Local State.camera-relay.bak")" == "$rich" ]]; then
+        ok "backup still holds the pre-install original after a second run"
+    else
+        bad "backup was refreshed and no longer matches the original"
+    fi
+else
+    bad "no backup created"
+fi
+
+# ── 4. libcamera version gate ────────────────────────────────────────────────
+# 0.2.0 is Ubuntu 24.04 / Zorin, where the PipeWire camera path has no IPU6
+# support. Enabling there trades "Chrome sees nothing" for "Chrome sees nothing
+# and the relay is bypassed too", so the gate has to hold.
+echo
+echo "libcamera version gate"
+
+gate_case() {
+    local desc="$1" version="$2" want="$3"; shift 3
+    local env_dir dir verdict
+    env_dir=$(new_env "$version")
+    dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{}}')
+    run_script "$env_dir" enable "$@" > /dev/null
+    if [[ "$(labs_of "$dir")" == "[\"$FLAG_ENTRY\"]" ]]; then
+        verdict="applied"
+    else
+        verdict="skipped"
+    fi
+    if [[ "$verdict" == "$want" ]]; then
+        ok "$(printf '%-32s %s' "$desc" "$want")"
+    else
+        bad "$(printf '%-32s expected %s, got %s' "$desc" "$want" "$verdict")"
+    fi
+}
+
+gate_case "libcamera 0.2.0"          "0.2.0" skipped
+gate_case "libcamera 0.5.2"          "0.5.2" skipped
+gate_case "libcamera 0.7"            "0.7"   applied
+gate_case "libcamera 0.7.2"          "0.7.2" applied
+gate_case "libcamera 0.10.0"         "0.10.0" applied
+gate_case "libcamera 1.0"            "1.0"   applied
+gate_case "version undeterminable"   ""      skipped
+gate_case "0.2.0 with --force"       "0.2.0" applied --force
+
+# ── 5. Running-browser guard ─────────────────────────────────────────────────
+# Chromium rewrites Local State from memory on exit. A write against a live
+# profile reports success and then vanishes, which is the worst outcome of all:
+# the installer claims it fixed the camera and it did not.
+echo
+echo "running-browser guard"
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{}}')
+ln -s "testhost-$$" "$dir/SingletonLock"     # our own PID: definitely alive
+out=$(run_script "$env_dir" enable)
+if [[ "$(labs_of "$dir")" == "MISSING" ]]; then
+    ok "live SingletonLock: profile left untouched"
+else
+    bad "live SingletonLock: wrote anyway → change would be lost on quit"
+fi
+if grep -q "is running" <<< "$out" && grep -q "chrome://flags" <<< "$out"; then
+    ok "live SingletonLock: says which browser and how to fix it by hand"
+else
+    bad "live SingletonLock: unhelpful message: $out"
+fi
+if [[ -f "$dir/Local State.camera-relay.bak" ]]; then
+    bad "live SingletonLock: took a backup for a write it never made"
+else
+    ok "live SingletonLock: no stray backup"
+fi
+
+# A crash leaves the lock behind. Refusing forever on a dead PID would strand
+# the user with no camera and no obvious reason.
+dead=$(bash -c 'echo $$')          # exited by the time we read it
+while kill -0 "$dead" 2>/dev/null; do dead=$((dead + 1)); done
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{}}')
+ln -s "testhost-$dead" "$dir/SingletonLock"
+run_script "$env_dir" enable > /dev/null
+if [[ "$(labs_of "$dir")" == "[\"$FLAG_ENTRY\"]" ]]; then
+    ok "stale SingletonLock: proceeds"
+else
+    bad "stale SingletonLock: refused on a dead PID"
+fi
+
+# ── 6. Profile discovery ─────────────────────────────────────────────────────
+echo
+echo "profile discovery"
+
+env_dir=$(new_env)
+chrome_dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{}}')
+brave_dir=$(make_profile "$env_dir" ".config/BraveSoftware/Brave-Browser" '{"browser":{}}')
+snap_dir=$(make_profile "$env_dir" "snap/chromium/current/.config/chromium" '{"browser":{}}')
+flat_dir=$(make_profile "$env_dir" ".var/app/com.google.Chrome/config/google-chrome" '{"browser":{}}')
+# Edge has no such flag — a profile here must be left alone, not half-configured.
+edge_dir=$(make_profile "$env_dir" ".config/microsoft-edge" '{"browser":{}}')
+run_script "$env_dir" enable > /dev/null
+for pair in "Chrome:$chrome_dir" "Brave:$brave_dir" "snap Chromium:$snap_dir" "flatpak Chrome:$flat_dir"; do
+    if [[ "$(labs_of "${pair#*:}")" == "[\"$FLAG_ENTRY\"]" ]]; then
+        ok "${pair%%:*} profile updated"
+    else
+        bad "${pair%%:*} profile missed"
+    fi
+done
+if [[ "$(labs_of "$edge_dir")" == "MISSING" ]]; then
+    ok "Edge left alone (no such flag exists there)"
+else
+    bad "Edge profile written with a flag Edge does not have"
+fi
+
+env_dir=$(new_env)
+out=$(run_script "$env_dir" enable)
+if grep -q "No Chromium-family browser profiles found" <<< "$out"; then
+    ok "no profiles: says so and exits clean"
+else
+    bad "no profiles: unexpected output: $out"
+fi
+
+# ── 7. disable / status ──────────────────────────────────────────────────────
+# The uninstallers call disable. It has to remove our entry and nothing else.
+echo
+echo "disable / status"
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" \
+    "{\"browser\":{\"enabled_labs_experiments\":[\"vulkan\",\"$FLAG_ENTRY\"]}}")
+run_script "$env_dir" disable > /dev/null
+if [[ "$(labs_of "$dir")" == '["vulkan"]' ]]; then
+    ok "disable removes ours, keeps theirs"
+else
+    bad "disable mangled the list: $(labs_of "$dir")"
+fi
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" \
+    "{\"browser\":{\"enabled_labs_experiments\":[\"$FLAG_ENTRY\"],\"x\":1}}")
+run_script "$env_dir" disable > /dev/null
+if [[ "$(labs_of "$dir")" == "MISSING" ]]; then
+    ok "disable drops the key when it empties out"
+else
+    bad "disable left an empty array behind: $(labs_of "$dir")"
+fi
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{}}')
+out=$(run_script "$env_dir" status)
+grep -q "absent" <<< "$out" && ok "status: absent" || bad "status: expected absent, got: $out"
+run_script "$env_dir" enable > /dev/null
+out=$(run_script "$env_dir" status)
+grep -q "enabled" <<< "$out" && ok "status: enabled" || bad "status: expected enabled, got: $out"
+# status must never write.
+cp -p "$dir/Local State" "$TMP/status-before"
+run_script "$env_dir" status > /dev/null
+cmp -s "$TMP/status-before" "$dir/Local State" \
+    && ok "status leaves the file alone" || bad "status modified the profile"
+
+# ── 8. Damaged profile ───────────────────────────────────────────────────────
+# Chromium itself recovers from a corrupt Local State. We must not make it worse
+# by truncating the file or writing a half-object over it.
+echo
+echo "damaged profile"
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" '{"browser":{"enabled_labs')
+out=$(run_script "$env_dir" enable)
+if [[ "$(cat "$dir/Local State")" == '{"browser":{"enabled_labs' ]]; then
+    ok "malformed JSON left byte-for-byte intact"
+else
+    bad "malformed JSON was overwritten"
+fi
+if grep -q "could not update profile" <<< "$out"; then
+    ok "malformed JSON reported, not swallowed"
+else
+    bad "malformed JSON failed silently: $out"
+fi
+if [[ -e "$dir/Local State.camera-relay.tmp" ]]; then
+    bad "left a temp file behind"
+else
+    ok "no temp file left behind"
+fi
+
+env_dir=$(new_env)
+dir=$(make_profile "$env_dir" ".config/google-chrome" '[1,2,3]')
+run_script "$env_dir" enable > /dev/null
+if [[ "$(cat "$dir/Local State")" == '[1,2,3]' ]]; then
+    ok "non-object JSON left intact"
+else
+    bad "non-object JSON was overwritten"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/camera-relay/tests/test-wireplumber-format-nudge.sh
+++ b/camera-relay/tests/test-wireplumber-format-nudge.sh
@@ -1,0 +1,336 @@
+#!/usr/bin/env bash
+# Regression tests for the WirePlumber format re-probe (nudge_wireplumber).
+#
+# v4l2loopback is loaded at boot with no producer, so it advertises a generic
+# catch-all format set — BGRx/xRGB at any size from 2x1 to 8192x8192, as a
+# Choice:Range. The relay's monitor pins YUYV 1920x1080 only when it starts at
+# login, and camera-relay.service is ordered After=wireplumber.service, so
+# WirePlumber has already probed the unconfigured device and never looks again.
+#
+# Firefox never notices — it reads /dev/video0 directly. WebRTC's PipeWire camera
+# path (Chrome, Brave, Electron) needs a discrete rectangle out of
+# SPA_PARAM_EnumFormat; a range yields no resolution, so the camera arrives with
+# zero capabilities and Chrome offers no device at all. This runs from
+# ExecStartPost to correct that.
+#
+# Three properties matter, and all three are easy to break silently:
+#   1. It must fire when the formats disagree — that is the whole point.
+#   2. It must NOT fire when they agree. This runs on every relay start, and an
+#      unconditional WirePlumber restart costs an audio glitch every time.
+#   3. It must always exit 0. It is an ExecStartPost, so a non-zero exit fails
+#      the relay unit and takes the camera down to fix a format mismatch.
+#
+# Usage: ./test-wireplumber-format-nudge.sh
+# Requires no camera hardware and no PipeWire, and touches no system state.
+
+set -uo pipefail
+
+RELAY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay"
+PASS=0
+FAIL=0
+
+ok()  { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad() { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+
+extract_fn() {
+    sed -n "/^$1()/,/^}/p" "$RELAY"
+}
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-wireplumber-format-nudge ($RELAY)"
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+# Stubs for the four tools the function shells out to. systemctl records its
+# invocation to a file so we can assert on whether a restart was requested,
+# without any user service being touched.
+new_env() {
+    local device_formats="$1" node_id="$2" pw_rect="$3"
+    local d="$TMP/env-$RANDOM$RANDOM"
+    mkdir -p "$d/bin"
+
+    # Always shadow v4l2-ctl. Merely omitting the stub would let the real one
+    # through — PATH is prepended, not replaced — and the test would silently
+    # query this machine's actual camera instead of the case under test.
+    if [[ -n "$device_formats" ]]; then
+        {
+            printf '#!/bin/sh\n'
+            printf 'printf "%%s\\n" "ioctl: VIDIOC_ENUM_FMT"\n'
+            printf 'printf "\\t%%s\\n" "Type: Video Capture"\n'
+            printf 'printf "\\t[0]: %%s\\n" "'"'"'%s'"'"' (raw)"\n' "${device_formats%% *}"
+            printf 'printf "\\t\\tSize: Discrete %%s\\n" "%s"\n' "${device_formats##* }"
+        } > "$d/bin/v4l2-ctl"
+    else
+        printf '#!/bin/sh\nexit 1\n' > "$d/bin/v4l2-ctl"
+    fi
+    chmod +x "$d/bin/v4l2-ctl"
+
+    cat > "$d/bin/pw-dump" << EOF
+#!/bin/sh
+if [ -n "$node_id" ]; then
+  printf '%s' '[{"id":$node_id,"info":{"props":{"media.class":"Video/Source","api.v4l2.path":"/dev/video0"}}}]'
+else
+  printf '%s' '[]'
+fi
+EOF
+
+    if [[ -n "$pw_rect" ]]; then
+        cat > "$d/bin/pw-cli" << EOF
+#!/bin/sh
+printf '    Prop: key Format:Video:format\n'
+printf '      Id 4        (Spa:Enum:VideoFormat:YUY2)\n'
+printf '        Rectangle $pw_rect\n'
+EOF
+    else
+        printf '#!/bin/sh\nexit 0\n' > "$d/bin/pw-cli"
+    fi
+
+    cat > "$d/bin/systemctl" << EOF
+#!/bin/sh
+echo "\$@" >> "$d/systemctl.calls"
+exit 0
+EOF
+
+    chmod +x "$d/bin/pw-dump" "$d/bin/pw-cli" "$d/bin/systemctl"
+    printf '%s\n' "$d"
+}
+
+# Runs nudge_wireplumber in isolation; echoes "restart"/"no-restart:<rc>".
+run_nudge() {
+    local env_dir="$1" rc
+    (
+        set -uo pipefail
+        PATH="$env_dir/bin:$PATH"
+        eval "$(extract_fn loopback_real_format)"
+        eval "$(extract_fn pipewire_node_for)"
+        eval "$(extract_fn nudge_wireplumber)"
+        info() { :; }
+        nudge_wireplumber /dev/video0
+    ) > /dev/null 2>&1
+    rc=$?
+    if grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
+        echo "restart:$rc"
+    else
+        echo "no-restart:$rc"
+    fi
+}
+
+# ── 1. Decision table ─────────────────────────────────────────────────────────
+echo
+echo "device format vs PipeWire's view → re-probe decision"
+
+nudge_case() {
+    local desc="$1" want="$2" dev_fmt="$3" node="$4" rect="$5"
+    local env_dir got verdict rc
+    env_dir=$(new_env "$dev_fmt" "$node" "$rect")
+    got=$(run_nudge "$env_dir")
+    verdict=${got%%:*}
+    rc=${got##*:}
+    if [[ "$verdict" == "$want" && "$rc" == "0" ]]; then
+        ok "$(printf '%-38s %s' "$desc" "$want")"
+    elif [[ "$rc" != "0" ]]; then
+        bad "$(printf '%-38s exited %s — would fail the relay unit' "$desc" "$rc")"
+    else
+        bad "$(printf '%-38s expected %s, got %s' "$desc" "$want" "$verdict")"
+    fi
+}
+
+# The bug this exists for: v4l2loopback's unconfigured catch-all range. pw-cli
+# renders the low bound of a Choice:Range first, hence 2x1.
+nudge_case "stale range (2x1) vs 1920x1080"  restart    "YUYV 1920x1080" 51 "2x1"
+# A resolution that was right for a previous relay config but is not any more.
+nudge_case "stale resolution 1280x720"       restart    "YUYV 1920x1080" 51 "1280x720"
+# The healthy state. Must stay silent — this runs on every single relay start.
+nudge_case "matching 1920x1080"              no-restart "YUYV 1920x1080" 51 "1920x1080"
+nudge_case "matching 1280x720"               no-restart "YUYV 1280x720"  51 "1280x720"
+# No node at all: WirePlumber never saw the device. A restart conjures nothing
+# and would just cost an audio glitch on every relay start.
+nudge_case "no PipeWire node for the device" no-restart "YUYV 1920x1080" "" "1920x1080"
+# Node exists but reports no format we can read — no evidence of a mismatch,
+# so no action. Guessing here would mean restarting WirePlumber forever.
+nudge_case "node with unreadable formats"    no-restart "YUYV 1920x1080" 51 ""
+# Without a working v4l2-ctl there is no ground truth to compare against, even
+# though PipeWire is reporting the exact range that normally means "stale".
+nudge_case "v4l2-ctl fails"                  no-restart ""               51 "2x1"
+
+# ── 2. Format parsing ─────────────────────────────────────────────────────────
+# The parse must not use a pipeline that exits early: piping v4l2-ctl into an
+# awk that exits on first match SIGPIPEs the writer, and under `set -o pipefail`
+# that surfaces as rc=141. The function then reports nothing, the caller reads
+# it as "no format", and the whole check silently disables itself.
+echo
+echo "format parsing"
+
+parse_case() {
+    local desc="$1" want="$2" dev_fmt="$3"
+    local env_dir got rc
+    env_dir=$(new_env "$dev_fmt" 51 "1920x1080")
+    got=$(
+        set -uo pipefail
+        PATH="$env_dir/bin:$PATH"
+        eval "$(extract_fn loopback_real_format)"
+        loopback_real_format /dev/video0
+    ); rc=$?
+    if [[ "$got" == "$want" && $rc -eq 0 ]]; then
+        ok "$(printf '%-30s %-22s rc=%s' "$desc" "$want" "$rc")"
+    else
+        bad "$(printf '%-30s expected %-18s got %-18s rc=%s' "$desc" "$want" "${got:-<empty>}" "$rc")"
+    fi
+}
+
+parse_case "YUYV 1920x1080" "YUYV 1920x1080" "YUYV 1920x1080"
+parse_case "YUYV 1280x720"  "YUYV 1280x720"  "YUYV 1280x720"
+parse_case "MJPG 640x480"   "MJPG 640x480"   "MJPG 640x480"
+
+# rc=0 specifically, not just non-empty output: 141 is what a SIGPIPE'd
+# pipeline returns and it is invisible in the output alone.
+env_dir=$(new_env "YUYV 1920x1080" 51 "1920x1080")
+(
+    set -uo pipefail
+    PATH="$env_dir/bin:$PATH"
+    eval "$(extract_fn loopback_real_format)"
+    loopback_real_format /dev/video0 > /dev/null
+)
+rc=$?
+if [[ $rc -eq 0 ]]; then
+    ok "parse exits 0 (not 141 from a SIGPIPE'd pipeline)"
+else
+    bad "parse exited $rc — a SIGPIPE here silently disables the whole check"
+fi
+
+# ── 3. The restart invocation itself ─────────────────────────────────────────
+# --no-block matters: the relay unit is After=wireplumber.service, so blocking
+# on a wireplumber job from inside our own ExecStartPost can deadlock.
+echo
+echo "restart invocation"
+
+env_dir=$(new_env "YUYV 1920x1080" 51 "2x1")
+run_nudge "$env_dir" > /dev/null
+calls=$(cat "$env_dir/systemctl.calls" 2>/dev/null)
+if grep -q -- '--user' <<< "$calls"; then
+    ok "restarts the *user* service (no sudo needed)"
+else
+    bad "not a --user restart: $calls"
+fi
+if grep -q -- '--no-block' <<< "$calls"; then
+    ok "uses --no-block (cannot deadlock against its own unit's ordering)"
+else
+    bad "missing --no-block: $calls"
+fi
+if grep -q 'wireplumber' <<< "$calls"; then
+    ok "targets wireplumber"
+else
+    bad "wrong target: $calls"
+fi
+if [[ $(wc -l <<< "$calls") -eq 1 ]]; then
+    ok "restarts exactly once"
+else
+    bad "restarted $(wc -l <<< "$calls") times"
+fi
+
+# ── 4. Waiting for the monitor ───────────────────────────────────────────────
+# The unit is Type=simple, so systemd runs ExecStartPost the moment ExecStart
+# forks — before the monitor has pinned YUYV on the loopback. A check that reads
+# the format once, right then, sees nothing, cannot tell that apart from
+# "nothing to do", and returns silently. The stale node then survives the entire
+# session, which is exactly the bug this whole file exists to prevent.
+echo
+echo "waiting for the monitor to pin the format"
+
+# v4l2-ctl reports no discrete format for the first two calls, as during relay
+# startup, then starts reporting 1920x1080.
+env_dir=$(new_env "YUYV 1920x1080" 51 "2x1")
+cat > "$env_dir/bin/v4l2-ctl" << EOF
+#!/bin/sh
+n=\$(cat "$env_dir/calls" 2>/dev/null || echo 0)
+echo \$((n + 1)) > "$env_dir/calls"
+printf 'ioctl: VIDIOC_ENUM_FMT\n'
+if [ "\$n" -ge 2 ]; then
+  printf '\t[0]: '"'"'YUYV'"'"' (raw)\n'
+  printf '\t\tSize: Discrete 1920x1080\n'
+fi
+EOF
+chmod +x "$env_dir/bin/v4l2-ctl"
+
+got=$(
+    (
+        set -uo pipefail
+        PATH="$env_dir/bin:$PATH"
+        eval "$(extract_fn loopback_real_format)"
+        eval "$(extract_fn pipewire_node_for)"
+        eval "$(extract_fn nudge_wireplumber)"
+        eval "$(extract_fn cmd_nudge_wireplumber)"
+        info() { :; }
+        detect_loopback_device() { echo /dev/video0; }
+        cmd_nudge_wireplumber
+        echo "rc=$?"
+    ) 2>&1 | tail -1
+)
+
+if grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
+    ok "waits for a late format, then re-probes ($(cat "$env_dir/calls") v4l2-ctl calls)"
+else
+    bad "gave up before the monitor pinned the format — stale node would survive the session"
+fi
+if [[ "$got" == "rc=0" ]]; then
+    ok "still exits 0 after waiting"
+else
+    bad "exited non-zero after waiting: $got"
+fi
+
+# A device that never reports a format must not hang the unit forever.
+env_dir=$(new_env "" 51 "2x1")
+start=$SECONDS
+(
+    set -uo pipefail
+    PATH="$env_dir/bin:$PATH"
+    eval "$(extract_fn loopback_real_format)"
+    eval "$(extract_fn pipewire_node_for)"
+    eval "$(extract_fn nudge_wireplumber)"
+    eval "$(extract_fn cmd_nudge_wireplumber)"
+    info() { :; }
+    detect_loopback_device() { echo /dev/video0; }
+    cmd_nudge_wireplumber
+) > /dev/null 2>&1
+elapsed=$((SECONDS - start))
+if (( elapsed <= 20 )); then
+    ok "gives up after a bounded wait (${elapsed}s), never hangs the unit"
+else
+    bad "waited ${elapsed}s — an unbounded wait would stall relay startup"
+fi
+if ! grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
+    ok "no restart when the format never appears"
+else
+    bad "restarted WirePlumber without ever reading a device format"
+fi
+
+# ── 5. Wiring ────────────────────────────────────────────────────────────────
+# The function is only reachable if the unit calls it and the dispatcher routes
+# it. Either one missing makes every test above pass while the fix does nothing.
+echo
+echo "wiring"
+
+if grep -q '^ExecStartPost=-\?/usr/local/bin/camera-relay nudge-wireplumber$' "$RELAY"; then
+    ok "generated unit has the ExecStartPost"
+else
+    bad "unit template is missing ExecStartPost — nudge would never run at boot"
+fi
+# The '-' prefix makes it advisory. Without it, anything that makes this exit
+# non-zero — most realistically a unit regenerated against an older
+# /usr/local/bin/camera-relay that has no such subcommand — fails the relay unit
+# and takes the camera away from every app to fix a browser-only problem.
+if grep -q '^ExecStartPost=-/usr/local/bin/camera-relay nudge-wireplumber$' "$RELAY"; then
+    ok "ExecStartPost is advisory ('-' prefix) — cannot take the relay down"
+else
+    bad "ExecStartPost lacks the '-' prefix — a failure here would kill the relay"
+fi
+if grep -qE '^\s*nudge-wireplumber\)' "$RELAY"; then
+    ok "dispatcher routes 'nudge-wireplumber'"
+else
+    bad "dispatcher has no nudge-wireplumber case — ExecStartPost would fail"
+fi
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/docs/triage/issue-54-findings.md
+++ b/docs/triage/issue-54-findings.md
@@ -163,3 +163,75 @@ filename`, `dkms status`, `ls /etc/modprobe.d/ | xargs grep -l clk_freq`,
 `grep -r ov02c10 /etc/modprobe.d/`, and post-reboot `dmesg | grep -i ov02c10`
 after re-running `ov02c10-26mhz-fix/install.sh` directly and completing MOK
 enrollment.
+
+---
+
+# Correction — the Phase 3 root cause was wrong
+
+**2026-08-04.** Phase 3 above attributes Chrome's blindness to the udev
+`ID_V4L_CAPABILITIES` property. That is not the mechanism, and the rule it
+shipped does not fix Chrome.
+
+Measured on a Book4 Ultra, Ubuntu 26.04, libcamera 0.7.2, v4l2loopback 0.15.3,
+Google Chrome 151 (deb, not snap), relay running, `70-camera-relay-capabilities.rules`
+installed and applied:
+
+```
+$ udevadm info --query=property --name=/dev/video0 | grep ID_V4L_CAPABILITIES
+ID_V4L_CAPABILITIES=:capture:
+```
+
+and in that same Chrome, on an https page:
+
+```json
+{ "cameraPermission": "prompt", "total": 2,
+  "videoinput": [],
+  "kinds": { "audioinput": 1, "audiooutput": 1 } }
+```
+
+The property is exactly what Phase 3 wanted it to be, and Chrome still lists no
+camera. Audio devices enumerate normally, so this is not permissions, not the
+sandbox, and not the relay.
+
+## What Chromium actually does
+
+`media/capture/video/linux/video_capture_device_factory_v4l2.cc` enumerates with
+`base::FileEnumerator` over `/dev/` matching `video*` and opens each candidate —
+it reads no udev property at all. The filter is a `VIDIOC_QUERYCAP` test:
+
+```c
+(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
+(cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
+ cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
+```
+
+Both branches require `!VIDEO_OUTPUT`. The relay node reports both:
+
+```
+Capabilities : 0x85200003   Video Capture + Video Output + ...
+Device Caps  : 0x05200003   Video Capture + Video Output + ...
+```
+
+so both branches fail and the node is dropped before any prompt. Firefox accepts
+dual caps and reads the node directly — hence the split this issue kept circling.
+
+This is a direct consequence of `exclusive_caps=0`, which the relay adopted
+deliberately (see the note above `nudge_wireplumber` in `camera-relay`) because
+`exclusive_caps=1` breaks WirePlumber's classification at boot instead. Fixing
+Chrome by reverting that would re-break Firefox, so the fix routes Chromium
+through PipeWire instead.
+
+## What changed
+
+- `camera-relay/chromium-pipewire-camera.sh` — enables
+  `chrome://flags/#enable-webrtc-pipewire-camera` in every Chromium-family
+  profile, called by both installers; `disable` is called by both uninstallers.
+- `camera-relay doctor` — evaluates Chromium's actual capability expression
+  against the live node instead of guessing, and reports the flag state per
+  browser profile.
+- `70-camera-relay-capabilities.rules` is **kept** — other udev consumers do read
+  the property — but its comments no longer claim it does anything for Chromium.
+- READMEs: `Chrome | Working | Works via V4L2 camera relay` was the opposite of
+  the truth and is corrected everywhere it appeared.

--- a/docs/triage/issue-65-findings.md
+++ b/docs/triage/issue-65-findings.md
@@ -557,3 +557,137 @@ not something confirmed from Chromium's side, and the docs are worded to match.
 
 No code path changed; `bash -n` clean on all three scripts and the suite is
 still 13/13.
+
+---
+
+# Round 6 — the dual-caps inference is now confirmed from Chromium's side
+
+**2026-08-04.** Round 5 ends with:
+
+> The dual-caps fact is measured; that it is *the* reason Chromium skips the
+> node is a strong inference, not something confirmed from Chromium's side, and
+> the docs are worded to match.
+
+It is confirmed. `media/capture/video/linux/video_capture_device_factory_v4l2.cc`
+gates every candidate node on:
+
+```c
+(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
+(cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
+ cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
+```
+
+Both branches require `!VIDEO_OUTPUT`, and the relay reports `0x05200003` —
+capture *and* output — so both fail. Enumeration itself is a `base::FileEnumerator`
+walk of `/dev/video*`, which also settles issue #54: no udev property is consulted
+anywhere in that path.
+
+## Consequences for how this was worded
+
+The docs said Chromium-family browsers "often will not" accept dual caps and are
+"stricter". Both understate it. The check is unconditional, so:
+
+- It is not setup-dependent and not a "some setups" problem. **No** Chromium-family
+  browser can ever see the relay node under `exclusive_caps=0`.
+- The flag is **required**, not a fallback for when Firefox works and Brave
+  doesn't. Round 5 already found users who needed it; every Chrome user needs it.
+- It applies to Edge and to Electron apps (Slack, Teams, Discord, VS Code), which
+  share the capture code. Edge has no such flag and cannot be fixed this way.
+
+Reproduced on a Book4 Ultra, Ubuntu 26.04, libcamera 0.7.2, Chrome 151 (deb, not
+snap, so sandboxing is not a factor): `enumerateDevices()` returns
+`videoinput: []` while audio devices enumerate normally, with the relay running
+and `ID_V4L_CAPABILITIES=:capture:` correctly set.
+
+## What changed
+
+- `camera-relay/chromium-pipewire-camera.sh` — sets the flag in every
+  Chromium-family profile (Chrome, Chromium incl. snap, Brave, Vivaldi, flatpaks),
+  gated on libcamera 0.7+, refusing while the browser is running because Chromium
+  rewrites `Local State` on exit. Both installers call it; both uninstallers call
+  `disable`. Covered by `camera-relay/tests/test-chromium-pipewire-flag.sh`.
+- `camera-relay doctor` — evaluates Chromium's expression against the live node
+  and reports the per-profile flag state instead of suggesting the user try it.
+- The top-level README claimed the installer already enabled this flag. No
+  installer did; now one does.
+
+---
+
+# Round 7 — the flag was necessary but not sufficient
+
+**2026-08-04.** Enabling `enable-webrtc-pipewire-camera` on the Book4 Ultra above
+did **not** make the camera appear. Chrome still returned:
+
+```js
+await navigator.mediaDevices.getUserMedia({video:true})
+// NotFoundError: Requested device not found
+```
+
+The flag itself was working — `--enable-features=WebRtcPipeWireCamera` reached
+every Chrome child process, and with `--vmodule=*pipewire*=3`:
+
+```
+camera_portal.cc:135]    Successfully created proxy for the portal.
+camera_portal.cc:215]    Camera access granted by the XDG portal.
+pipewire_session.cc:99]  Found Camera: Camera Relay (V4L2)
+pipewire_session.cc:427] Enumerating PipeWire camera devices complete.
+```
+
+Chrome **finds** the camera and then offers no device. The portal was fine too:
+`IsCameraPresent` was `true`, the permission store held
+`{'com.google.Chrome': ['yes']}`, and `media.role=Camera` was set on the node.
+
+## The node's format list is stale
+
+```
+$ pw-cli enum-params <node> EnumFormat        $ v4l2-ctl -d /dev/video0 --list-formats-ext
+  VideoFormat:BGRx                              [0]: 'YUYV' (YUYV 4:2:2)
+  Rectangle 2x1  →  8192x8192  (Choice:Range)        Size: Discrete 1920x1080
+```
+
+PipeWire is advertising v4l2loopback's unconfigured catch-all set, not the format
+the relay actually pins. WebRTC's PipeWire camera path needs a discrete rectangle
+out of `SPA_PARAM_EnumFormat`; a `Choice:Range` yields no resolution, so the
+device is built with zero capabilities — found, unusable.
+
+**Why:** v4l2loopback loads at boot from `modules-load.d` with no producer. The
+relay's monitor pins `YUYV 1920x1080` only at login, and `camera-relay.service`
+is ordered `After=wireplumber.service`, so WirePlumber always probes the
+unconfigured device and never re-probes. Firefox is immune because it reads
+`/dev/video0` directly and never consults PipeWire's format list.
+
+Confirmed by an actual reboot mid-investigation: the flag survived, the node
+regressed to `BGRx / Rectangle 2x1`, and Chrome went back to finding nothing.
+
+## Fix
+
+`nudge_wireplumber` is back in `camera-relay`, called from `ExecStartPost`. It
+waits for the monitor to pin the format (ExecStartPost runs as soon as
+`Type=simple` ExecStart *forks*, which is too early — the first attempt read no
+format at all and silently did nothing), compares it against what PipeWire
+advertises, and restarts WirePlumber only when they disagree.
+
+The two reasons it was removed in the first place do not apply where it now runs:
+
+- *"sudo prompt blocks/confuses users"* — that was `udevadm trigger`, needed
+  because the legacy `v4l2-relayd` is a **system** service. `camera-relay` is a
+  user service, so `systemctl --user` needs no privileges, and the restart alone
+  is sufficient; the udev event only ever mattered for the caps flip.
+- *"restart disrupts active camera streams"* — at relay start nothing is
+  streaming yet.
+
+`ExecStartPost` carries a `-` prefix: this is a browser-only correction and must
+never take down a relay that works for every V4L2 app.
+
+Verified by simulating the boot race — stop relay, restart WirePlumber (node goes
+to `BGRx 2x1`), start relay → `YUY2 1920x1080`, relay still active. Covered by
+`camera-relay/tests/test-wireplumber-format-nudge.sh` (22 assertions).
+
+## Note for future triage
+
+Two independent bugs stacked here, and each one alone fully explains the symptom
+"Chrome has no camera". Fixing only the first leaves the symptom unchanged, which
+is exactly how #54 and #65 both landed on the wrong mechanism. `camera-relay
+doctor` now checks both.

--- a/webcam-fix-book5/README.md
+++ b/webcam-fix-book5/README.md
@@ -167,13 +167,14 @@ libcamera on IPU7 currently supports only one client at a time. If Firefox is us
 
 ### Browser & App Compatibility
 
-With `exclusive_caps=0` (the default), browsers work best using V4L2 directly through the camera relay:
+Apps split into two groups, and which group a browser lands in is not a matter of
+configuration — see [Chromium can't use the V4L2 relay](#chromium-cant-use-the-v4l2-relay) below.
 
 | App | Status | Notes |
 |-----|--------|-------|
-| **Firefox** | Working | Works via PipeWire (no flags needed) |
-| **Chrome / Chromium / Brave** | Working | Works via V4L2 camera relay |
-| **Edge** | Working | Works via V4L2 camera relay only |
+| **Firefox** | Working | Reads the V4L2 relay directly; also works via PipeWire. No flags needed |
+| **Chrome / Chromium / Brave** | Working | **Only** via PipeWire — the installer enables the flag for you |
+| **Edge** | Not working | Same V4L2 filter as Chrome, but no PipeWire flag exists to work around it |
 | **Zoom / OBS / VLC** | Working | Uses V4L2 camera relay |
 | **Cheese** | Crashes | Use standalone fix: `cd ../camera-relay && ./cheese-fix.sh` |
 
@@ -243,46 +244,117 @@ restart of xdg-desktop-portal is needed.
 V4L2 camera relay, which needs no flags. Thanks to
 [@david-bartlett](https://github.com/david-bartlett) ([#37](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/37)).
 
-**Chrome / Chromium / Edge:** These browsers work via the V4L2 camera relay without any special flags. Make sure the relay is running:
-```bash
-camera-relay status
-camera-relay enable-persistent --yes  # if not enabled
-```
-
-If Chrome still shows "waiting for your permission" without a prompt, try:
+**Chrome / Chromium / Brave:** see the next section — these need the PipeWire
+flag, which the installer sets for you. If Chrome shows "waiting for your
+permission" without a prompt but *does* list the camera, try:
 1. Go to `chrome://settings/content/camera` and ensure the correct camera is selected
 2. Clear site permissions for the page you're testing
 3. Try an Incognito window (to rule out extension conflicts)
 
-### Firefox sees the camera but Brave / Chromium don't
+### Chromium can't use the V4L2 relay
 
-Enable the PipeWire camera flag in the Chromium-family browser:
+Chrome, Chromium, Brave, Edge and every Electron app filter the camera relay out
+of their device list before you ever see a permission prompt —
+`navigator.mediaDevices.enumerateDevices()` simply returns no `videoinput`.
 
+This is not a permission, sandbox or relay problem. Chromium's V4L2 enumeration
+([`video_capture_device_factory_v4l2.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/media/capture/video/linux/video_capture_device_factory_v4l2.cc))
+accepts a node only when it reports capture and **not** output:
+
+```c
+(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
+(cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
+ cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
 ```
-chrome://flags/#enable-webrtc-pipewire-camera   →  Enabled
+
+The relay is created with `exclusive_caps=0`, so it advertises both
+(`v4l2-ctl -d /dev/videoN --info` shows `Video Capture` *and* `Video Output`
+under `Device Caps`) and every branch fails. Firefox accepts dual caps and reads
+the node directly, which is exactly why Firefox works out of the box and Chrome
+shows nothing. Snap and flatpak browsers are additionally sandboxed away from
+`/dev/video*`.
+
+**The fix** is to route those browsers through PipeWire, where WirePlumber
+publishes the relay as an ordinary camera source. The installer does this, and
+you can run it any time:
+
+```bash
+cd camera-relay && ./chromium-pipewire-camera.sh
 ```
 
-Then fully quit and reopen the browser — Chromium caches its device list at
-startup, so a page reload is not enough.
-
-Why the two browsers differ: the relay node is created with `exclusive_caps=0`,
-so it advertises **both** `Video Capture` and `Video Output`
-(`v4l2-ctl -d /dev/videoN --info` shows both under `Device Caps`). Firefox
-accepts that and reads the device directly over V4L2; Chromium-family browsers
-are stricter about it, and browsers installed as snaps or flatpaks are sandboxed
-away from `/dev/video*` entirely. The flag routes them through PipeWire instead,
-where WirePlumber presents the relay as an ordinary camera. Confirmed on a
+It enables `chrome://flags/#enable-webrtc-pipewire-camera` in each browser's
+`Local State` (backing the file up first); you can also set that flag by hand.
+Either way the browser must be **fully quit** first — Chromium rewrites
+`Local State` from memory on exit and would discard the change — and restarted
+afterwards, since it caches its device list at startup. Confirmed on a
 960QHA / Kubuntu 26.04 in [issue #65](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/65).
 
-**Two exceptions where the flag is the wrong move:**
+`camera-relay doctor` reports the node's actual capabilities, whether PipeWire
+publishes a camera source, and whether the flag is set per browser.
 
-- **Ubuntu 24.04 (Noble) / Zorin**, where the system libcamera is **0.2.0** and
-  has no IPU6/IPU7 support. There the flag makes Chrome take that broken path
-  and bypass the working V4L2 relay, so the camera is *not* found. Check with
-  `pkg-config --modversion libcamera` — at **0.7 or newer the flag is safe**,
-  and that is where the older "keep it disabled" advice comes from.
-- **Edge**, which doesn't support the flag at all. It works through the V4L2
-  relay only.
+#### The second half: WirePlumber's stale format list
+
+The flag alone is not enough, because a second timing bug sits behind it.
+
+`v4l2loopback` is loaded at boot with no producer attached, so it advertises a
+generic catch-all format set — `BGRx`/`xRGB` at any size from 2x1 to 8192x8192,
+expressed as a `Choice:Range`. The relay's monitor only pins `YUYV 1920x1080`
+when it starts at login, and `camera-relay.service` is ordered
+`After=wireplumber.service` — so WirePlumber has already probed the unconfigured
+device, cached that generic list, and will never look again.
+
+Firefox never notices, because it reads `/dev/video0` directly. WebRTC's PipeWire
+camera path needs a *discrete* rectangle out of `SPA_PARAM_EnumFormat`; a range
+yields no usable resolution, so the camera arrives with zero capabilities. Chrome
+logs the camera and then offers no device — indistinguishable from no camera:
+
+```
+camera_portal.cc:215]    Camera access granted by the XDG portal.
+pipewire_session.cc:99]  Found Camera: Camera Relay (V4L2)
+```
+```js
+await navigator.mediaDevices.getUserMedia({video:true})
+// NotFoundError: Requested device not found
+```
+
+Compare the two views to spot it:
+
+```bash
+v4l2-ctl -d /dev/videoN --list-formats-ext   # what the device really offers
+pw-cli enum-params <node-id> EnumFormat      # what PipeWire thinks it offers
+```
+
+There is no lighter re-probe available — the V4L2 monitor is udev-driven, nodes
+are built at discovery, and WirePlumber exposes no "re-probe this device" call.
+Restarting it is the documented answer; see *"`device.capabilities` is read-only
+in PipeWire"* in [the legacy fix](../webcam-fix/README.md#step-9-fix-pipewire-device-classification),
+which hit the same class of bug.
+
+The relay handles this itself, from `ExecStartPost`: it waits for the monitor to
+pin the format, compares it against what PipeWire advertises, and restarts
+WirePlumber **only** when they disagree — so restarting the relay by hand costs
+no audio glitch when things are already correct. Run it manually with:
+
+```bash
+camera-relay nudge-wireplumber
+```
+
+Two things this does **not** fix:
+
+- **Edge** has no such flag. It stays blind to the relay.
+- **libcamera 0.2.0** (Ubuntu 24.04 Noble / Zorin) has no IPU6/IPU7 support, so
+  the PipeWire path produces no frames either. Check with
+  `pkg-config --modversion libcamera`; the script refuses below 0.7, and that is
+  where the older "keep the flag disabled" advice came from.
+
+> **Why not `exclusive_caps=1`?** It would make the node advertise capture only
+> and fix every Chromium app at once, with no flag. The relay deliberately moved
+> away from it: with `exclusive_caps=1` WirePlumber classifies the node as an
+> output at boot, before the relay attaches, and the PipeWire path breaks instead
+> — trading one broken set of apps for another. See the note above
+> `nudge_wireplumber` in `camera-relay/camera-relay`.
 
 If enabling it makes things worse, set it back to Disabled — it is a per-browser
 setting and changes nothing system-wide.

--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -1046,22 +1046,30 @@ if [[ -d "$RELAY_DIR" ]]; then
     echo "v4l2loopback" | sudo tee /etc/modules-load.d/v4l2loopback.conf > /dev/null
     echo "  ✓ Installed v4l2loopback autoload (/etc/modules-load.d/v4l2loopback.conf)"
 
-    # Chromium/Chrome enumerate V4L2 cameras through udev and only list
-    # devices whose ID_V4L_CAPABILITIES udev property contains ":capture:".
-    # v4l_id (60-persistent-v4l.rules) tags the node ONCE at device creation
-    # — while the relay monitor holds the writer fd and no capture format is
-    # negotiated yet — so the property can come up without ":capture:" and
-    # Chrome never lists the camera (even though it streams capture fine, and
-    # libcamera/PipeWire apps like Cheese/Firefox work). Force the capture
-    # capability for the relay node so Chrome enumerates it. (issue #54)
+    # v4l_id (60-persistent-v4l.rules) tags the node ONCE at device creation —
+    # while the relay monitor holds the writer fd and no capture format is
+    # negotiated yet — so ID_V4L_CAPABILITIES can come up without ":capture:"
+    # and udev-based consumers misread the node. Normalise it here.
+    #
+    # This was originally added believing it was what made Chrome list the
+    # camera (issue #54). It is not: Chromium enumerates with base::FileEnumerator
+    # over /dev/video* and opens each node with VIDIOC_QUERYCAP — it never reads
+    # a udev property. Chrome stays blind to the relay with this rule applied and
+    # ID_V4L_CAPABILITIES=":capture:" set, because the node reports VIDEO_OUTPUT
+    # alongside VIDEO_CAPTURE. That is handled by the PipeWire flag below.
+    # The rule is kept because other udev consumers do read the property.
     sudo tee /etc/udev/rules.d/70-camera-relay-capabilities.rules > /dev/null << 'EOF'
-# Force ID_V4L_CAPABILITIES so Chromium/Chrome's udev-based V4L2 camera
-# enumeration lists the Camera Relay loopback. Runs after 60-persistent-v4l.
+# Normalise ID_V4L_CAPABILITIES for the Camera Relay loopback: v4l_id tags the
+# node before any capture format is negotiated, so the property can come up
+# without ":capture:". Runs after 60-persistent-v4l.
+#
+# Note: this does NOT affect Chromium. It enumerates /dev/video* directly and
+# never reads udev properties — see the PipeWire camera flag instead.
 SUBSYSTEM=="video4linux", ATTR{name}=="Camera Relay", ENV{ID_V4L_CAPABILITIES}=":capture:"
 EOF
     sudo udevadm control --reload-rules
     sudo udevadm trigger --action=change --subsystem-match=video4linux
-    echo "  ✓ Installed Camera Relay udev capabilities rule (Chrome/Chromium fix)"
+    echo "  ✓ Installed Camera Relay udev capabilities rule"
 
     # Rebuild initramfs so it picks up the new v4l2loopback config.
     # Without this, v4l2loopback may load from initramfs with stale
@@ -1171,6 +1179,19 @@ EOF
     else
         echo "Could not detect logged-in user — icons not installed"
     fi
+
+    # Chromium-family browsers cannot see the relay node at all. Their V4L2
+    # enumeration accepts a device only when it reports VIDEO_CAPTURE and *not*
+    # VIDEO_OUTPUT, and the relay under exclusive_caps=0 reports both — so
+    # Chrome, Brave, Edge and every Electron app list zero cameras while Firefox
+    # (which accepts dual caps) works. Point them at PipeWire instead, where
+    # WirePlumber already publishes the relay as an ordinary camera source.
+    # Advisory: never fail the install over a browser preference.
+    if [[ -x "$RELAY_DIR/chromium-pipewire-camera.sh" ]]; then
+        echo ""
+        echo "  Configuring Chromium-family browsers..."
+        "$RELAY_DIR/chromium-pipewire-camera.sh" enable || true
+    fi
 else
     echo "  ⚠ camera-relay directory not found — skipping relay tool installation"
 fi
@@ -1267,12 +1288,13 @@ echo "  Browser setup (if camera doesn't appear in browser):"
 echo "    Firefox:  about:config → media.webrtc.camera.allow-pipewire = true"
 echo "              For full resolution: media.navigator.video.default_width = 1920"
 echo "                                   media.navigator.video.default_height = 1080"
-echo "    Chrome:   Works out of the box with the V4L2 camera relay"
-echo "    Brave/Chromium: if Firefox sees the camera but these don't, enable"
-echo "      chrome://flags/#enable-webrtc-pipewire-camera and fully restart the"
-echo "      browser. Safe on libcamera 0.7+ (check: pkg-config --modversion"
-echo "      libcamera); leave it OFF on Ubuntu 24.04/Zorin, where libcamera"
-echo "      0.2.0 has no IPU6 support and the flag breaks the relay path."
+echo "    Chrome/Chromium/Brave: cannot see the V4L2 relay at all — they only"
+echo "      accept a device that reports capture WITHOUT output, and the relay"
+echo "      reports both. They go through PipeWire instead, which is what the"
+echo "      flag above enables. If it was skipped because the browser was open,"
+echo "      quit it and run: camera-relay/chromium-pipewire-camera.sh"
+echo "    Edge:     no such flag exists — it stays blind to the relay."
+echo "    Run 'camera-relay doctor' to see the flag state per browser."
 echo ""
 echo "  Non-PipeWire apps (Zoom, OBS, VLC) use the on-demand camera relay."
 echo "  The relay is enabled and will auto-start on login (near-zero idle CPU)."

--- a/webcam-fix-book5/uninstall.sh
+++ b/webcam-fix-book5/uninstall.sh
@@ -102,6 +102,14 @@ sudo rm -f /etc/udev/rules.d/70-camera-relay-capabilities.rules
 sudo udevadm control --reload-rules 2>/dev/null || true
 echo "  ✓ Udev rules removed"
 
+# Take the Chromium PipeWire camera flag back out. Left behind it would point
+# those browsers at a PipeWire camera that no longer exists.
+_UNINST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -x "$_UNINST_DIR/../camera-relay/chromium-pipewire-camera.sh" ]]; then
+    echo "  Reverting Chromium browser camera flag..."
+    "$_UNINST_DIR/../camera-relay/chromium-pipewire-camera.sh" disable || true
+fi
+
 # [7/11] Remove WirePlumber rules
 echo "[7/11] Removing WirePlumber rules..."
 sudo rm -f /etc/wireplumber/wireplumber.conf.d/50-disable-ipu7-v4l2.conf

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -144,33 +144,36 @@ The webcam works correctly with: **Firefox**, **Chrome/Chromium/Brave**, **Zoom*
 
 ### Browser & App Compatibility
 
-With `exclusive_caps=0` (the default), browsers work best using V4L2 directly through the camera relay, without PipeWire camera flags:
+Apps split into two groups, and which group a browser lands in is not a matter of
+configuration — see [Chromium can't use the V4L2 relay](#chromium-cant-use-the-v4l2-relay) below.
 
 | App | Status | Notes |
 |-----|--------|-------|
-| **Firefox** | Working | Works via PipeWire (no flags needed) |
-| **Chrome** | Working | Works via V4L2 camera relay. PipeWire flag optional but can cause issues. |
+| **Firefox** | Working | Reads the V4L2 relay directly; also works via PipeWire. No flags needed |
+| **Chrome** | Working | **Only** via PipeWire — the installer enables the flag for you |
 | **Chromium** | Working | Same as Chrome |
 | **Brave** | Working | Same as Chrome |
-| **Edge** | Working | Works via V4L2 camera relay only. No PipeWire support. |
+| **Edge** | Not working | Same V4L2 filter as Chrome, but no PipeWire flag exists to work around it |
 | **Zoom** | Working | Uses V4L2 camera relay |
 | **OBS Studio** | Working | Uses V4L2 camera relay |
 | **VLC** | Working | Uses V4L2 camera relay |
 | **Cheese** | Crashes | Use standalone fix: `cd ../camera-relay && ./cheese-fix.sh` |
 | **GNOME Camera** | May crash | Workaround: `LIBGL_ALWAYS_SOFTWARE=1 snapshot` |
 
-**Note on `chrome://flags/#enable-webrtc-pipewire-camera`:** whether you want this
-depends on your libcamera version, so check `pkg-config --modversion libcamera`
-first.
+**`chrome://flags/#enable-webrtc-pipewire-camera` is required for Chromium-family
+browsers, not optional** — with one version-specific exception. Check with
+`pkg-config --modversion libcamera`:
 
+- **libcamera 0.7+: enable it.** This is what the installer does automatically,
+  and what `camera-relay/chromium-pipewire-camera.sh` does on demand.
 - **libcamera 0.2.0 (Ubuntu 24.04 Noble / Zorin): leave it Disabled.** That
-  libcamera has no IPU6 support, so the flag makes Chrome take a broken path and
-  bypass the working V4L2 relay — see the troubleshooting section below.
-- **libcamera 0.7+: safe, and sometimes required.** If Firefox sees the camera
-  but Brave or Chromium don't, enable it and fully restart the browser
-  ([issue #65](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/65)).
+  libcamera has no IPU6 support, so the flag sends Chrome down a path that
+  produces no frames either. Neither setting gives you a camera there; fix the
+  libcamera version instead.
 
-Edge doesn't support the flag at all and works through the V4L2 relay only.
+Electron apps (Slack, Teams, Discord, VS Code) use the same Chromium capture
+code and are affected the same way. Launch them with
+`--enable-features=WebRTCPipeWireCamera` if they can't see the camera.
 
 Quick test:
 
@@ -337,24 +340,111 @@ If you don't specifically need the PipeWire path, setting
 camera relay, which needs no flags. Thanks to
 [@david-bartlett](https://github.com/david-bartlett) ([#37](https://github.com/Andycodeman/samsung-galaxy-book-linux-fixes/issues/37)).
 
-### Chromium browser doesn't show camera
+### Chromium can't use the V4L2 relay
 
-Chrome/Chromium/Brave/Edge see the camera through the **V4L2 camera relay**, not PipeWire. Make sure the relay is running:
+Chrome, Chromium, Brave, Edge and every Electron app filter the camera relay out
+of their device list before you ever see a permission prompt —
+`navigator.mediaDevices.enumerateDevices()` simply returns no `videoinput`.
 
-```bash
-camera-relay status
-camera-relay enable-persistent --yes  # if not enabled
+This is not a permission, sandbox or relay problem. Chromium's V4L2 enumeration
+([`video_capture_device_factory_v4l2.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/media/capture/video/linux/video_capture_device_factory_v4l2.cc))
+accepts a node only when it reports capture and **not** output:
+
+```c
+(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
+(cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
+ cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
+ !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
 ```
 
-**On Ubuntu/Zorin (Noble), keep `chrome://flags/#enable-webrtc-pipewire-camera` DISABLED.** There the PipeWire camera path goes through the system libcamera 0.2.0, which has no IPU6 support — enabling the flag makes Chrome use that broken path and bypass the working V4L2 relay entirely (the camera will *not* be found). This is specific to that libcamera version: run `pkg-config --modversion libcamera`, and if it reports **0.7 or newer** the flag is safe, and on some setups Chromium and Brave need it (issue #65).
-
-If Chrome shows "camera not found" even with the relay streaming and the flag off: Chromium enumerates V4L2 cameras through **udev** and only lists devices whose `ID_V4L_CAPABILITIES` property contains `:capture:`. `v4l_id` tags the loopback once at device creation — before any capture format is negotiated — so the property can come up without `:capture:` and Chrome silently filters the device out (libcamera/PipeWire apps like Cheese and Firefox are unaffected, which is why they still work). The installer ships a udev rule (`/etc/udev/rules.d/70-camera-relay-capabilities.rules`) that forces the capture capability for the relay node. Check it with:
+The relay is created with `exclusive_caps=0`, so it advertises both and every
+branch fails:
 
 ```bash
-udevadm info /dev/videoN | grep -i ID_V4L_CAPABILITIES   # the "Camera Relay" node
+v4l2-ctl -d /dev/videoN --info    # Device Caps: Video Capture AND Video Output
 ```
 
-After installing, **fully quit Chrome** (`pkill -9 -f chrome` — Chrome caches its device list and keeps a background process) before relaunching.
+Firefox accepts dual caps and reads the node directly, which is exactly why
+Firefox works out of the box and Chrome shows nothing.
+
+**The fix** is to route those browsers through PipeWire, where WirePlumber
+publishes the relay as an ordinary camera source. The installer does this, and
+you can run it any time:
+
+```bash
+cd camera-relay && ./chromium-pipewire-camera.sh
+```
+
+It edits each browser's `Local State` to enable
+`chrome://flags/#enable-webrtc-pipewire-camera` (backing the file up first), or
+you can set that flag by hand. Either way the browser must be **fully quit**
+first — Chromium rewrites `Local State` from memory on exit and would discard the
+change — and restarted afterwards, since it caches its device list at startup.
+
+`camera-relay doctor` reports all of this: the node's actual capabilities, whether
+PipeWire publishes a camera source, and whether the flag is set per browser.
+
+#### The second half: WirePlumber's stale format list
+
+The flag alone is not enough, because a second timing bug sits behind it.
+
+`v4l2loopback` is loaded at boot with no producer attached, so it advertises a
+generic catch-all format set — `BGRx`/`xRGB` at any size from 2x1 to 8192x8192,
+expressed as a `Choice:Range`. The relay's monitor only pins `YUYV 1920x1080`
+when it starts at login, and `camera-relay.service` is ordered
+`After=wireplumber.service` — so WirePlumber has already probed the unconfigured
+device, cached that generic list, and will never look again.
+
+Firefox never notices, because it reads `/dev/video0` directly. WebRTC's PipeWire
+camera path needs a *discrete* rectangle out of `SPA_PARAM_EnumFormat`; a range
+yields no usable resolution, so the camera arrives with zero capabilities. Chrome
+logs the camera and then offers no device — indistinguishable from no camera:
+
+```
+camera_portal.cc:215]    Camera access granted by the XDG portal.
+pipewire_session.cc:99]  Found Camera: Camera Relay (V4L2)
+```
+```js
+await navigator.mediaDevices.getUserMedia({video:true})
+// NotFoundError: Requested device not found
+```
+
+Compare the two views to spot it:
+
+```bash
+v4l2-ctl -d /dev/videoN --list-formats-ext   # what the device really offers
+pw-cli enum-params <node-id> EnumFormat      # what PipeWire thinks it offers
+```
+
+There is no lighter re-probe available — the V4L2 monitor is udev-driven, nodes
+are built at discovery, and WirePlumber exposes no "re-probe this device" call.
+Restarting it is the documented answer; see *"`device.capabilities` is read-only
+in PipeWire"* in [the legacy fix](../webcam-fix/README.md#step-9-fix-pipewire-device-classification),
+which hit the same class of bug.
+
+The relay handles this itself, from `ExecStartPost`: it waits for the monitor to
+pin the format, compares it against what PipeWire advertises, and restarts
+WirePlumber **only** when they disagree — so restarting the relay by hand costs
+no audio glitch when things are already correct. Run it manually with:
+
+```bash
+camera-relay nudge-wireplumber
+```
+
+Two things this does **not** fix:
+
+- **Edge** has no such flag. It stays blind to the relay.
+- **libcamera 0.2.0** (Ubuntu 24.04 Noble / Zorin) has no IPU6 support, so the
+  PipeWire path produces no frames either. The script refuses to enable the flag
+  below 0.7 for that reason.
+
+> **Why not `exclusive_caps=1`?** It would make the node advertise capture only
+> and fix every Chromium app at once, with no flag. The relay deliberately moved
+> away from it: with `exclusive_caps=1` WirePlumber classifies the node as an
+> output at boot, before the relay attaches, and the PipeWire path breaks instead
+> — trading one broken set of apps for another. See the note above
+> `nudge_wireplumber` in `camera-relay/camera-relay`.
 
 ### Black screen in apps / "v4l2loopback ... não é um dispositivo de saída"
 

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -1845,22 +1845,30 @@ if [[ -d "$RELAY_DIR" ]]; then
     echo "v4l2loopback" | sudo tee /etc/modules-load.d/v4l2loopback.conf > /dev/null
     echo "  ✓ Installed v4l2loopback autoload (/etc/modules-load.d/v4l2loopback.conf)"
 
-    # Chromium/Chrome enumerate V4L2 cameras through udev and only list
-    # devices whose ID_V4L_CAPABILITIES udev property contains ":capture:".
-    # v4l_id (60-persistent-v4l.rules) tags the node ONCE at device creation
-    # — while the relay monitor holds the writer fd and no capture format is
-    # negotiated yet — so the property can come up without ":capture:" and
-    # Chrome never lists the camera (even though it streams capture fine, and
-    # libcamera/PipeWire apps like Cheese/Firefox work). Force the capture
-    # capability for the relay node so Chrome enumerates it. (issue #54)
+    # v4l_id (60-persistent-v4l.rules) tags the node ONCE at device creation —
+    # while the relay monitor holds the writer fd and no capture format is
+    # negotiated yet — so ID_V4L_CAPABILITIES can come up without ":capture:"
+    # and udev-based consumers misread the node. Normalise it here.
+    #
+    # This was originally added believing it was what made Chrome list the
+    # camera (issue #54). It is not: Chromium enumerates with base::FileEnumerator
+    # over /dev/video* and opens each node with VIDIOC_QUERYCAP — it never reads
+    # a udev property. Chrome stays blind to the relay with this rule applied and
+    # ID_V4L_CAPABILITIES=":capture:" set, because the node reports VIDEO_OUTPUT
+    # alongside VIDEO_CAPTURE. That is handled by the PipeWire flag below.
+    # The rule is kept because other udev consumers do read the property.
     sudo tee /etc/udev/rules.d/70-camera-relay-capabilities.rules > /dev/null << 'EOF'
-# Force ID_V4L_CAPABILITIES so Chromium/Chrome's udev-based V4L2 camera
-# enumeration lists the Camera Relay loopback. Runs after 60-persistent-v4l.
+# Normalise ID_V4L_CAPABILITIES for the Camera Relay loopback: v4l_id tags the
+# node before any capture format is negotiated, so the property can come up
+# without ":capture:". Runs after 60-persistent-v4l.
+#
+# Note: this does NOT affect Chromium. It enumerates /dev/video* directly and
+# never reads udev properties — see the PipeWire camera flag instead.
 SUBSYSTEM=="video4linux", ATTR{name}=="Camera Relay", ENV{ID_V4L_CAPABILITIES}=":capture:"
 EOF
     sudo udevadm control --reload-rules
     sudo udevadm trigger --action=change --subsystem-match=video4linux
-    echo "  ✓ Installed Camera Relay udev capabilities rule (Chrome/Chromium fix)"
+    echo "  ✓ Installed Camera Relay udev capabilities rule"
 
     # Rebuild initramfs so it picks up the new v4l2loopback config.
     # Without this, v4l2loopback may load from initramfs with stale
@@ -1979,6 +1987,19 @@ EOF
             || echo "gtk-update-icon-cache failed — icons may not appear until next login"
     else
         echo "Could not detect logged-in user — icons not installed"
+    fi
+
+    # Chromium-family browsers cannot see the relay node at all. Their V4L2
+    # enumeration accepts a device only when it reports VIDEO_CAPTURE and *not*
+    # VIDEO_OUTPUT, and the relay under exclusive_caps=0 reports both — so
+    # Chrome, Brave, Edge and every Electron app list zero cameras while Firefox
+    # (which accepts dual caps) works. Point them at PipeWire instead, where
+    # WirePlumber already publishes the relay as an ordinary camera source.
+    # Advisory: never fail the install over a browser preference.
+    if [[ -x "$RELAY_DIR/chromium-pipewire-camera.sh" ]]; then
+        echo ""
+        echo "  Configuring Chromium-family browsers..."
+        "$RELAY_DIR/chromium-pipewire-camera.sh" enable || true
     fi
 else
     echo "  ⚠ camera-relay directory not found — skipping"
@@ -2101,12 +2122,13 @@ fi
 echo ""
 echo "  Browser setup:"
 echo "    Firefox:  Works out of the box (no flags needed)"
-echo "    Chrome:   Works out of the box with the V4L2 camera relay"
-echo "    Brave/Chromium: if Firefox sees the camera but these don't, enable"
-echo "      chrome://flags/#enable-webrtc-pipewire-camera and fully restart the"
-echo "      browser. Safe on libcamera 0.7+ (check: pkg-config --modversion"
-echo "      libcamera); leave it OFF on Ubuntu 24.04/Zorin, where libcamera"
-echo "      0.2.0 has no IPU6 support and the flag breaks the relay path."
+echo "    Chrome/Chromium/Brave: cannot see the V4L2 relay at all — they only"
+echo "      accept a device that reports capture WITHOUT output, and the relay"
+echo "      reports both. They go through PipeWire instead, which is what the"
+echo "      flag above enables. If it was skipped because the browser was open,"
+echo "      quit it and run: camera-relay/chromium-pipewire-camera.sh"
+echo "    Edge:     no such flag exists — it stays blind to the relay."
+echo "    Run 'camera-relay doctor' to see the flag state per browser."
 echo ""
 echo "  Cheese fix (if needed):"
 echo "    Cheese crashes with this camera. A standalone fix is available:"

--- a/webcam-fix-libcamera/uninstall.sh
+++ b/webcam-fix-libcamera/uninstall.sh
@@ -149,6 +149,14 @@ if getent group camera-relay >/dev/null 2>&1; then
 fi
 echo "  ✓ Udev rules removed"
 
+# Take the Chromium PipeWire camera flag back out. Left behind it would point
+# those browsers at a PipeWire camera that no longer exists.
+_UNINST_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -x "$_UNINST_DIR/../camera-relay/chromium-pipewire-camera.sh" ]]; then
+    echo "  Reverting Chromium browser camera flag..."
+    "$_UNINST_DIR/../camera-relay/chromium-pipewire-camera.sh" disable || true
+fi
+
 # [5/8] Remove WirePlumber rules
 echo "[5/8] Removing WirePlumber rules..."
 sudo rm -f /etc/wireplumber/main.lua.d/51-disable-ipu6-v4l2.lua


### PR DESCRIPTION
Chrome, Chromium, Brave, Edge and every Electron app list **no camera at all** after install, while Firefox works on the first try. Two independent bugs were stacked behind that, and **each one alone fully explains the symptom** — which is how #54 and #65 both landed on the wrong mechanism.

Reproduced on a Galaxy Book4 Ultra, Ubuntu 26.04, kernel 7.0.0-28, libcamera 0.7.2, v4l2loopback 0.15.3, Google Chrome 151 (deb — not snap, so sandboxing is not a factor), relay running and healthy.

```js
// before
await navigator.mediaDevices.enumerateDevices()
// { videoinput: [], audioinput: 1, audiooutput: 1 }   ← audio enumerates fine
```

Not a permission problem (state was `prompt`), not the sandbox, not the relay.

## Bug 1 — Chromium filters the relay node out of V4L2 enumeration

[`video_capture_device_factory_v4l2.cc`](https://chromium.googlesource.com/chromium/src/+/refs/heads/main/media/capture/video/linux/video_capture_device_factory_v4l2.cc) accepts a node only when it reports capture and **not** output:

```c
(cap.capabilities & V4L2_CAP_VIDEO_CAPTURE &&
 !(cap.capabilities & V4L2_CAP_VIDEO_OUTPUT)) ||
(cap.capabilities & V4L2_CAP_DEVICE_CAPS &&
 cap.device_caps & V4L2_CAP_VIDEO_CAPTURE &&
 !(cap.device_caps & V4L2_CAP_VIDEO_OUTPUT))
```

Under `exclusive_caps=0` the relay reports both (`caps 0x85200003`, `device caps 0x05200003`), so both branches fail and the node is dropped before any prompt. Firefox accepts dual caps and reads the node directly — the whole reason the two disagree.

**Corrections to the record:**

- **#54** attributed this to the udev `ID_V4L_CAPABILITIES` property. Chromium enumerates with `base::FileEnumerator` over `/dev/video*` and never reads udev — the property was already `:capture:` on the reproducing machine and Chrome still saw nothing. `70-camera-relay-capabilities.rules` is **kept** (other udev consumers do read it) but its comments no longer claim it does anything for Chromium.
- **#65** called dual caps *"a strong inference, not something confirmed from Chromium's side"*. Now confirmed from the source. It also understated the scope: the check is unconditional, so this is not a "some setups" problem and the flag is **required**, not a fallback.

**Fix:** `camera-relay/chromium-pipewire-camera.sh` enables `chrome://flags/#enable-webrtc-pipewire-camera` across Chrome, Chromium (incl. snap), Brave, Vivaldi and flatpaks. Gated on libcamera 0.7+, refuses while the browser is running (Chromium rewrites `Local State` on exit and would silently discard the write), backs the file up, byte-idempotent. Both installers call it; both uninstallers call `disable`.

> The top-level README already claimed *"the installer automatically enables the PipeWire camera flag"*. No installer did — the only matches were `echo` lines telling the user to do it by hand. Now one does.

`exclusive_caps=1` would fix this at the source with no flag, but that reopens the WirePlumber classification problem this project deliberately moved away from. Documented as a trade-off rather than changed.

## Bug 2 — WirePlumber caches a stale format list, so the flag alone changes nothing

Enabling the flag did **not** make the camera appear. The flag was working:

```
camera_portal.cc:215]    Camera access granted by the XDG portal.
pipewire_session.cc:99]  Found Camera: Camera Relay (V4L2)
```

Chrome *finds* the camera and offers no device, because the node's formats are stale:

```
pw-cli enum-params <node> EnumFormat     v4l2-ctl -d /dev/video0 --list-formats-ext
  VideoFormat:BGRx                         [0]: 'YUYV' (YUYV 4:2:2)
  Rectangle 2x1 → 8192x8192 (Range)             Size: Discrete 1920x1080
```

`v4l2loopback` loads at boot with no producer and advertises its catch-all range. The monitor pins `YUYV 1920x1080` only at login, and `camera-relay.service` is ordered `After=wireplumber.service` — so WirePlumber always probes the unconfigured device and never looks again. WebRTC needs a **discrete** rectangle out of `SPA_PARAM_EnumFormat`; a range yields no resolution, so the camera is built with zero capabilities. Firefox is immune: it never consults PipeWire's format list.

Confirmed by an actual reboot mid-investigation — the flag survived, the node regressed to `BGRx / Rectangle 2x1`, Chrome went back to finding nothing.

**Fix:** `nudge_wireplumber` returns, from `ExecStartPost`. The two reasons it was removed do not apply where it now runs:

- *"sudo prompt blocks/confuses users"* — that was `udevadm trigger`, needed only because the legacy `v4l2-relayd` is a **system** service. `camera-relay` is a user service, so `systemctl --user` needs no privileges, and the restart alone is sufficient.
- *"restart disrupts active camera streams"* — nothing is streaming at relay start.

It waits for the monitor to pin the format (`ExecStartPost` runs as soon as a `Type=simple` `ExecStart` *forks*, which is too early — the first attempt read no format and silently did nothing), and restarts WirePlumber **only** when the formats disagree, so a manual relay restart costs no audio glitch. The `-` prefix keeps a browser-only correction from ever taking the relay down.

This matches the conclusion already recorded in `webcam-fix/README.md` for the legacy stack: *"`device.capabilities` is read-only in PipeWire … The only fix is to make WirePlumber re-discover the device after the relay attaches."* There is no lighter re-probe — the V4L2 monitor is udev-driven and WirePlumber exposes no per-device reprobe call.

## Result

```json
{ "videoinput": ["Camera Relay (V4L2)"],
  "frame": "1920x1080", "frameRate": 30,
  "distinctColors": 2004, "verdict": "REAL PICTURE" }
```

## Also

- `camera-relay doctor` now **evaluates** Chromium's capability expression against the live node, compares PipeWire's advertised format against the device's, and reports the flag state per browser profile — instead of suggesting the user try things.
- `Chrome | Working | Works via V4L2 camera relay` in the compatibility tables was the opposite of the truth; corrected everywhere. Edge is now listed as not working, since no flag exists to work around it there.
- Findings recorded in `docs/triage/issue-54-findings.md` and `issue-65-findings.md`.

## Verification

- Boot race simulated end to end: stop relay → restart WirePlumber (node goes to `BGRx 2x1`) → start relay → `YUY2 1920x1080`, relay still active.
- 63 new assertions across two suites (`test-chromium-pipewire-flag.sh`, `test-wireplumber-format-nudge.sh`); **125 total, all passing** across the seven suites in `camera-relay/tests/`.
- `bash -n` clean on every touched script. `shellcheck -S warning` reports **no new warnings versus `main`**: the three new scripts are at zero, and each pre-existing one carries exactly the count it already had on `main` (`camera-relay` 1, `webcam-fix-book5/install.sh` 7, `webcam-fix-libcamera/install.sh` 9, `webcam-fix-book5/uninstall.sh` 1).
- Rebased onto `main` (`4dc3825`). The branch previously sat on `1f30ca6`, before the setgid pipeline launcher landed, so its `camera-relay` predated that work — running this branch's `install.sh` would have reinstalled a relay that invokes `gst-launch-1.0` directly instead of `camera-relay-gst`, leaving it unable to open the raw nodes. The rebase resolves cleanly and touches none of that code; the numbers above are measured post-rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
