### PR TITLE
camera-relay: build the launcher on Book5, and stop skipping the unit on reinstall

### DIFF
--- a/camera-relay/camera-relay
+++ b/camera-relay/camera-relay
@@ -764,8 +764,22 @@ cmd_nudge_wireplumber() {
     # silently and the stale node would survive the whole session. Wait for the
     # monitor, bounded, then compare. (The legacy v4l2-relayd fix papered over
     # the same race with a flat `sleep 2`.)
+    # systemd takes the unit through start-post even when ExecStart has already
+    # failed, so this can be running alongside a relay that is not there. Left
+    # unchecked the wait below burns its full 15s on every restart attempt of a
+    # relay that cannot start — turning a RestartSec=5 recovery loop into 20s a
+    # cycle and filling the journal with a format complaint that is not the
+    # problem. Observed for real against a machine missing camera-relay-gst.
+    #
+    # The grace period covers the opposite race: ExecStartPost can beat
+    # ExecStart to writing the PID file, and treating that as "relay is gone"
+    # would disable the check on every healthy boot.
     local waited=0
     while [[ -z "$(loopback_real_format "$dev")" ]] && (( waited < 15 )); do
+        if (( waited >= 5 )) && ! is_running; then
+            info "Relay is not running — skipping WirePlumber check"
+            return 0
+        fi
         sleep 1
         waited=$((waited + 1))
     done
@@ -1577,12 +1591,23 @@ cmd_enable_persistent() {
     local skip_confirm=false
     [[ "${1:-}" == "--yes" ]] && skip_confirm=true
 
+    # Deliberately does NOT bail out here when persistent mode is already on.
+    # The unit is not static — it carries LIBCAMERA_IPA_MODULE_PATH,
+    # GST_PLUGIN_PATH, LD_LIBRARY_PATH, LIBCAMERA_SOFTISP_MODE,
+    # __EGL_VENDOR_LIBRARY_FILENAMES and the nudge-wireplumber ExecStartPost,
+    # all computed here at install time. Returning early meant a reinstall
+    # refreshed every binary and left the unit at whatever it was first created
+    # with, so fixes that live *in the unit* shipped installed and inert while
+    # the installer reported success: the EGL pin from #76 (black camera) and
+    # the WirePlumber re-probe from v0.3.62 (no camera in Chrome) both landed
+    # that way. The quiet no-op is preserved below by comparing content, not by
+    # skipping the work. (issue #82)
+    local already=false
     if is_persistent; then
-        info "Persistent mode is already enabled"
-        return 0
+        already=true
     fi
 
-    if ! $skip_confirm; then
+    if ! $already && ! $skip_confirm; then
         echo ""
         echo "  ┌──────────────────────────────────────────────────┐"
         echo "  │           On-Demand Camera Relay                 │"
@@ -1695,9 +1720,14 @@ cmd_enable_persistent() {
         info "NVIDIA GPU detected, no iGPU to pin — using CPU debayer"
     fi
 
-    # Create systemd user service
+    # Create systemd user service. Rendered to a temp file first and compared
+    # against what is installed, so an unchanged reinstall stays a genuine
+    # no-op — no daemon-reload, no restart, no camera dropped out from under
+    # whoever is using it.
     mkdir -p "$SERVICE_DIR"
-    cat > "${SERVICE_DIR}/${SERVICE_NAME}" <<EOF
+    local unit_path="${SERVICE_DIR}/${SERVICE_NAME}"
+    local unit_tmp="${unit_path}.new"
+    cat > "$unit_tmp" <<EOF
 [Unit]
 Description=Camera Relay (on-demand libcamera to v4l2loopback)
 After=pipewire.service wireplumber.service
@@ -1730,7 +1760,34 @@ ${egl_vendor:+Environment=__EGL_VENDOR_LIBRARY_FILENAMES=$egl_vendor}
 WantedBy=default.target
 EOF
 
+    local unit_changed=true
+    if [[ -f "$unit_path" ]] && cmp -s "$unit_tmp" "$unit_path"; then
+        unit_changed=false
+    fi
+    if $unit_changed; then
+        mv -f "$unit_tmp" "$unit_path"
+    else
+        rm -f "$unit_tmp"
+    fi
+
+    if $already && ! $unit_changed; then
+        info "Persistent mode is already enabled (service unit is up to date)"
+        return 0
+    fi
+
     systemctl --user daemon-reload
+
+    if $already; then
+        # Already enabled, but the unit content moved. Restart, or the running
+        # relay keeps the old environment until the next login — which is how
+        # the EGL pin stayed inert on machines that had the fix installed.
+        info "Service unit changed — restarting the relay to pick it up"
+        systemctl --user enable "$SERVICE_NAME" >/dev/null 2>&1 || true
+        systemctl --user restart "$SERVICE_NAME"
+        info "On-demand relay updated and restarted"
+        return 0
+    fi
+
     systemctl --user enable --now "$SERVICE_NAME"
 
     info "On-demand relay enabled"

--- a/camera-relay/tests/test-unit-regeneration.sh
+++ b/camera-relay/tests/test-unit-regeneration.sh
@@ -1,0 +1,218 @@
+#!/usr/bin/env bash
+# Regression tests for service-unit regeneration on reinstall (issue #82).
+#
+# cmd_enable_persistent used to return the moment persistent mode was already
+# on, and the unit is written well after that point. So a reinstall refreshed
+# every binary and left the unit at whatever it was first created with.
+#
+# That matters because the unit is not static. It carries
+# LIBCAMERA_IPA_MODULE_PATH, GST_PLUGIN_PATH, LD_LIBRARY_PATH,
+# LIBCAMERA_SOFTISP_MODE, __EGL_VENDOR_LIBRARY_FILENAMES and the
+# nudge-wireplumber ExecStartPost — all computed at install time. Two shipped
+# fixes died there: the hybrid-GPU EGL pin (#76, black camera) and the
+# WirePlumber format re-probe (v0.3.62, no camera in Chrome). Both arrived
+# installed and inert while the installer reported success.
+#
+# Four properties, each easy to break in the opposite direction:
+#   1. Already enabled + stale unit  → rewrite it. That is the bug.
+#   2. Already enabled + same unit   → touch nothing. An unconditional rewrite
+#      would daemon-reload and restart the relay on every reinstall, dropping
+#      the camera out from under whoever is using it.
+#   3. A changed unit must be followed by a restart, or the running relay keeps
+#      the old environment until the next login — which is exactly how the EGL
+#      pin stayed inert on machines that had the fix.
+#   4. Never leave the .new temp file behind in the unit directory; systemd
+#      would not load it, but `camera-relay.service.new` sitting in
+#      ~/.config/systemd/user is alarming and looks like a failed install.
+#
+# Usage: ./test-unit-regeneration.sh
+# Requires no camera hardware and touches no system state.
+
+set -uo pipefail
+
+RELAY="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)/camera-relay"
+PASS=0
+FAIL=0
+
+ok()  { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad() { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-unit-regeneration ($RELAY)"
+
+# ── Harness ───────────────────────────────────────────────────────────────────
+# Same shape as test-egl-vendor-pin.sh: stub every probe so the run is hermetic,
+# point SERVICE_DIR at a temp dir, and record systemctl instead of running it.
+#
+# $1 = "enabled" | "disabled"  (what is_persistent reports)
+# $2 = path to a file to pre-seed as the installed unit, or empty for none
+#
+# A *path*, not a string: `$(cat unit)` strips the trailing newline, so seeding
+# from a captured variable produces a file that differs from the generated one
+# by exactly one byte and every "unchanged" case looks changed.
+run_enable() {
+    local persistent="$1" existing="$2"
+    local outdir="$TMP/unit-$RANDOM$RANDOM"
+    mkdir -p "$outdir"
+    [[ -n "$existing" ]] && cp "$existing" "$outdir/camera-relay.service"
+    (
+        set -euo pipefail
+        # shellcheck disable=SC1090
+        source "$RELAY" -h >/dev/null 2>&1 || true
+        SERVICE_DIR="$outdir"
+        if [[ "$persistent" == enabled ]]; then
+            is_persistent() { return 0; }
+        else
+            is_persistent() { return 1; }
+        fi
+        require_gst_tools() { return 0; }
+        detect_ipa_path() { return 1; }
+        detect_gst_plugin_path() { return 1; }
+        detect_libcamera_lib_path() { return 1; }
+        detect_egl_vendor_pin() { return 1; }
+        systemctl() { echo "$*" >> "$outdir/systemctl.calls"; return 0; }
+        cmd_enable_persistent --yes >/dev/null 2>&1
+        echo "rc=$?" > "$outdir/rc"
+    ) >/dev/null 2>&1
+    printf '%s\n' "$outdir"
+}
+
+calls_of() { cat "$1/systemctl.calls" 2>/dev/null; }
+unit_of()  { cat "$1/camera-relay.service" 2>/dev/null; }
+
+# A unit as it would have been generated before v0.3.62 — no ExecStartPost.
+# This is the concrete shape of the bug: real machines are running this today.
+STALE_UNIT="$TMP/stale.service"
+cat > "$STALE_UNIT" <<'EOF'
+[Unit]
+Description=Camera Relay (on-demand libcamera to v4l2loopback)
+After=pipewire.service wireplumber.service
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/camera-relay start --on-demand
+ExecStop=/usr/local/bin/camera-relay stop
+Restart=on-failure
+RestartSec=5
+
+[Install]
+WantedBy=default.target
+EOF
+
+# ── 1. The bug: already enabled, stale unit ──────────────────────────────────
+echo
+echo "already enabled, unit predates the current version"
+
+d=$(run_enable enabled "$STALE_UNIT")
+if grep -q '^ExecStartPost=-/usr/local/bin/camera-relay nudge-wireplumber$' <<< "$(unit_of "$d")"; then
+    ok "stale unit is regenerated (gains the nudge-wireplumber ExecStartPost)"
+else
+    bad "stale unit left untouched — this is issue #82, the fix is inert"
+fi
+if grep -q 'daemon-reload' <<< "$(calls_of "$d")"; then
+    ok "daemon-reload issued after rewriting"
+else
+    bad "no daemon-reload — systemd keeps serving the old unit"
+fi
+if grep -qE '(^|[[:space:]])restart camera-relay\.service$' <<< "$(calls_of "$d")"; then
+    ok "relay restarted so the running process picks up the new unit"
+else
+    bad "no restart — the running relay keeps the old environment until login"
+fi
+if [[ ! -e "$d/camera-relay.service.new" ]]; then
+    ok "no .new temp file left in the unit directory"
+else
+    bad "left camera-relay.service.new behind"
+fi
+
+# ── 2. Already enabled, unit already correct ─────────────────────────────────
+# The other half. An unconditional rewrite would restart the relay on every
+# single reinstall, which is a dropped camera for anyone mid-call.
+echo
+echo "already enabled, unit already up to date"
+
+d=$(run_enable enabled "")            # first pass generates the current unit
+CURRENT_UNIT="$TMP/current.service"
+if [[ -s "$d/camera-relay.service" ]] && cp "$d/camera-relay.service" "$CURRENT_UNIT"; then
+    ok "baseline current unit captured"
+else
+    bad "could not generate a baseline unit"
+fi
+
+d=$(run_enable enabled "$CURRENT_UNIT")
+if cmp -s "$d/camera-relay.service" "$CURRENT_UNIT"; then
+    ok "identical unit left byte-for-byte alone"
+else
+    bad "rewrote a unit that was already correct"
+fi
+if [[ -z "$(calls_of "$d")" ]]; then
+    ok "no systemctl at all — genuine no-op reinstall"
+else
+    bad "touched systemd for an unchanged unit: $(calls_of "$d")"
+fi
+if [[ ! -e "$d/camera-relay.service.new" ]]; then
+    ok "no .new temp file left behind on the no-op path"
+else
+    bad "left camera-relay.service.new behind on the no-op path"
+fi
+
+# ── 3. Fresh enable ──────────────────────────────────────────────────────────
+# The path that already worked. It has to keep working: `enable --now` is what
+# makes the relay start at login in the first place.
+echo
+echo "not yet enabled"
+
+d=$(run_enable disabled "")
+if grep -q '^ExecStart=/usr/local/bin/camera-relay start --on-demand$' <<< "$(unit_of "$d")"; then
+    ok "unit written"
+else
+    bad "no unit written on a fresh enable"
+fi
+if grep -q 'enable --now camera-relay.service' <<< "$(calls_of "$d")"; then
+    ok "enable --now issued"
+else
+    bad "missing enable --now: $(calls_of "$d")"
+fi
+if ! grep -qE '(^|[[:space:]])restart camera-relay\.service$' <<< "$(calls_of "$d")"; then
+    ok "no redundant restart (enable --now already starts it)"
+else
+    bad "restarted on top of enable --now"
+fi
+
+# ── 4. Already enabled, unit missing entirely ────────────────────────────────
+# Someone deleted it by hand, or an older uninstall removed the unit and left
+# the symlink. Previously this returned "already enabled" and wrote nothing,
+# leaving a service that cannot start.
+echo
+echo "already enabled, unit file missing"
+
+d=$(run_enable enabled "")
+if [[ -n "$(unit_of "$d")" ]]; then
+    ok "missing unit is recreated rather than reported as fine"
+else
+    bad "no unit written — service would stay unstartable"
+fi
+
+# ── 5. Exit status ───────────────────────────────────────────────────────────
+# install.sh runs this with `&& echo ✓ || echo ⚠`, so a non-zero exit on the
+# no-op path would report a failed install on every reinstall.
+echo
+echo "exit status"
+
+for case_desc in "enabled|$CURRENT_UNIT|unchanged unit" \
+                 "enabled|$STALE_UNIT|stale unit" \
+                 "disabled||no unit"; do
+    IFS='|' read -r state seed label <<< "$case_desc"
+    d=$(run_enable "$state" "$seed")
+    if [[ "$(cat "$d/rc" 2>/dev/null)" == "rc=0" ]]; then
+        ok "$(printf '%-32s exits 0' "$state, $label")"
+    else
+        bad "$(printf '%-32s exited %s' "$state, $label" "$(cat "$d/rc" 2>/dev/null || echo '?')")"
+    fi
+done
+
+echo
+echo "  $PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/camera-relay/tests/test-wireplumber-format-nudge.sh
+++ b/camera-relay/tests/test-wireplumber-format-nudge.sh
@@ -262,6 +262,7 @@ got=$(
         eval "$(extract_fn nudge_wireplumber)"
         eval "$(extract_fn cmd_nudge_wireplumber)"
         info() { :; }
+        is_running() { return 0; }
         detect_loopback_device() { echo /dev/video0; }
         cmd_nudge_wireplumber
         echo "rc=$?"
@@ -290,6 +291,7 @@ start=$SECONDS
     eval "$(extract_fn nudge_wireplumber)"
     eval "$(extract_fn cmd_nudge_wireplumber)"
     info() { :; }
+    is_running() { return 0; }
     detect_loopback_device() { echo /dev/video0; }
     cmd_nudge_wireplumber
 ) > /dev/null 2>&1
@@ -303,6 +305,65 @@ if ! grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
     ok "no restart when the format never appears"
 else
     bad "restarted WirePlumber without ever reading a device format"
+fi
+
+# systemd runs ExecStartPost even when ExecStart has already failed — the unit
+# goes through start-post regardless of the main process's fate. So this can be
+# waiting on a format for a relay that is not there, and burning the full 15s
+# every time turns a RestartSec=5 recovery loop into 20s a cycle. Observed on a
+# real machine whose camera-relay-gst was missing.
+env_dir=$(new_env "" 51 "2x1")
+start=$SECONDS
+(
+    set -uo pipefail
+    PATH="$env_dir/bin:$PATH"
+    eval "$(extract_fn loopback_real_format)"
+    eval "$(extract_fn pipewire_node_for)"
+    eval "$(extract_fn nudge_wireplumber)"
+    eval "$(extract_fn cmd_nudge_wireplumber)"
+    info() { :; }
+    is_running() { return 1; }          # ExecStart died
+    detect_loopback_device() { echo /dev/video0; }
+    cmd_nudge_wireplumber
+) > /dev/null 2>&1
+rc=$?
+elapsed=$((SECONDS - start))
+if (( elapsed < 12 )); then
+    ok "dead relay: gives up early (${elapsed}s), not the full wait"
+else
+    bad "dead relay: still waited ${elapsed}s — slows every restart attempt"
+fi
+if [[ $rc -eq 0 ]]; then
+    ok "dead relay: still exits 0"
+else
+    bad "dead relay: exited $rc — would compound the failure"
+fi
+if ! grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
+    ok "dead relay: no WirePlumber restart"
+else
+    bad "dead relay: restarted WirePlumber anyway"
+fi
+
+# The grace period matters as much as the check: ExecStartPost can beat
+# ExecStart to writing the PID file, and bailing on that would disable the
+# whole check on every healthy boot.
+env_dir=$(new_env "YUYV 1920x1080" 51 "2x1")
+(
+    set -uo pipefail
+    PATH="$env_dir/bin:$PATH"
+    eval "$(extract_fn loopback_real_format)"
+    eval "$(extract_fn pipewire_node_for)"
+    eval "$(extract_fn nudge_wireplumber)"
+    eval "$(extract_fn cmd_nudge_wireplumber)"
+    info() { :; }
+    is_running() { return 1; }          # PID file not written yet...
+    detect_loopback_device() { echo /dev/video0; }
+    cmd_nudge_wireplumber
+) > /dev/null 2>&1
+if grep -q 'restart' "$env_dir/systemctl.calls" 2>/dev/null; then
+    ok "format already available: acts before the liveness check can bite"
+else
+    bad "liveness check disabled a re-probe the device was ready for"
 fi
 
 # ── 5. Wiring ────────────────────────────────────────────────────────────────

--- a/webcam-fix-book5/install.sh
+++ b/webcam-fix-book5/install.sh
@@ -1110,6 +1110,35 @@ EOF
         fi
     fi
 
+    # Build and install the pipeline launcher (C binary).
+    #
+    # Not optional: since v0.3.59 the relay does not shell out to gst-launch-1.0
+    # itself, it execs this launcher, and camera-relay `die`s at start when the
+    # binary is absent. This installer never built it, so every Book5 install
+    # after v0.3.59 produced a relay that could not start. (issue #85, reported
+    # by @david-bartlett)
+    #
+    # Installed plain 755 here, NOT setgid. The setgid treatment in
+    # webcam-fix-libcamera exists to reach raw MC nodes that its udev rule moves
+    # into the memberless camera-relay group; this installer ships neither that
+    # group nor that rule, so the nodes stay in 'video' and the desktop user
+    # already has them. camera-relay-gst handles egid == gid explicitly and runs
+    # fine. Porting the full setgid + udev hardening across is issue #70 and
+    # wants a Book5 tester, not a same-day patch.
+    if [[ -f "$RELAY_DIR/camera-relay-gst.c" ]]; then
+        echo "  Building pipeline launcher..."
+        if gcc -O2 -Wall -o /tmp/camera-relay-gst "$RELAY_DIR/camera-relay-gst.c"; then
+            sudo install -m 755 /tmp/camera-relay-gst /usr/local/bin/camera-relay-gst
+            rm -f /tmp/camera-relay-gst
+            echo "  ✓ Installed /usr/local/bin/camera-relay-gst"
+        else
+            echo "  ⚠ Failed to build camera-relay-gst (gcc required) — the relay"
+            echo "    will not start. Install gcc and re-run this script."
+        fi
+    else
+        echo "  ⚠ camera-relay-gst.c not found in $RELAY_DIR — the relay will not start"
+    fi
+
     # Install CLI tool
     sudo cp "$RELAY_DIR/camera-relay" /usr/local/bin/camera-relay
     sudo chmod 755 /usr/local/bin/camera-relay

--- a/webcam-fix-book5/uninstall.sh
+++ b/webcam-fix-book5/uninstall.sh
@@ -192,6 +192,7 @@ while IFS=: read -r user _ _ _ _ home _; do
 done < <(getent passwd)
 sudo rm -f /usr/local/bin/camera-relay
 sudo rm -f /usr/local/bin/camera-relay-monitor
+sudo rm -f /usr/local/bin/camera-relay-gst
 sudo rm -rf /usr/local/share/camera-relay
 sudo rm -f /usr/share/applications/camera-relay-systray.desktop
 sudo rm -f /etc/xdg/autostart/camera-relay-systray.desktop


### PR DESCRIPTION
Fixes #85 and #82. Both end the same way: a fix that is **installed and inert** while the installer reports success.

## 1. Book5 never built `camera-relay-gst` (#85, found by @david-bartlett)

Since v0.3.59 the relay execs the launcher instead of shelling out to `gst-launch-1.0`, and `camera-relay` dies at start when it is missing:

```
ERROR: camera-relay-gst not found at /usr/local/bin/camera-relay-gst.
```

`webcam-fix-book5/install.sh` had **zero** references to it (the libcamera installer has 10), so every Book5 install after v0.3.59 produced a relay that could not start.

Installed plain `755`, deliberately **not** setgid. The setgid treatment in `webcam-fix-libcamera` exists to reach raw MC nodes that its udev rule moves into the memberless `camera-relay` group; this installer ships neither that group nor that rule, so the nodes stay in `video` and the desktop user already has them. `camera-relay-gst` handles `egid == gid` explicitly and runs fine. Porting the full setgid + udev hardening across is #70 and wants a Book5 tester, not a same-day patch. The uninstaller now removes it.

## 2. `enable-persistent` skipped the unit on reinstall (#82, filed by @4nrry)

`cmd_enable_persistent` returned as soon as persistent mode was on, and the unit is written well after that point. The unit is not static — it carries `LIBCAMERA_IPA_MODULE_PATH`, `GST_PLUGIN_PATH`, `LD_LIBRARY_PATH`, `LIBCAMERA_SOFTISP_MODE`, `__EGL_VENDOR_LIBRARY_FILENAMES` and the `nudge-wireplumber` `ExecStartPost`. Two shipped fixes died there: the hybrid-GPU EGL pin (#76, black camera) and the WirePlumber re-probe (v0.3.62, no camera in Chrome).

The unit is now always rendered, compared against what is installed, and replaced only when it differs — so an unchanged reinstall stays a true no-op (no `daemon-reload`, no restart, no camera dropped mid-call) and a changed one is followed by a restart rather than waiting for the next login.

## 3. Bonus: `ExecStartPost` ran its full wait against a dead relay

Introduced with the re-probe in v0.3.62 and caught by running this on real hardware. systemd takes the unit through start-post **even when `ExecStart` has already failed**, so the nudge burned its whole 15s wait on every restart attempt of a relay that could not start — turning a `RestartSec=5` recovery loop into 20s a cycle:

```
Active: activating (start-post) (Result: exit-code)
Process: ExecStart=… (code=exited, status=1/FAILURE)
├─ bash /usr/local/bin/camera-relay nudge-wireplumber
└─ sleep 1
```

It now bails once the relay is known dead, after a grace period covering the opposite race (ExecStartPost beating ExecStart to the PID file).

## Verification

Real hardware — a Book4 Ultra (960XGL, libcamera 0.7.2) that turned out to be in exactly the state #82 describes: unit with no `ExecStartPost`, and no `camera-relay-gst`.

```
before   ExecStartPost lines in installed unit: 0
run 1    Service unit changed — restarting the relay to pick it up
         WirePlumber has stale formats for /dev/video0 (sees 2x1, device offers 1920x1080)
         → PipeWire now advertises 1920x1080, matching the device
run 2    Persistent mode is already enabled (service unit is up to date)
         unit unchanged: YES   relay NOT restarted: YES   stray .new file: none
healthy  restart 1s — "WirePlumber already sees 1920x1080 — no re-probe needed"
```

New `test-unit-regeneration.sh` (15 assertions) locks in both directions — regenerate when stale, touch nothing when current — plus 4 new cases in `test-wireplumber-format-nudge.sh` for the dead-relay bail. **145 assertions across eight suites, all passing.** `bash -n` clean on every touched script.

🤖 Generated with [Claude Code](https://claude.com/claude-code)