### PR TITLE
camera-relay: fix the PipeWire camera feature name, which Chromium was ignoring

### DIFF
--- a/camera-relay/chromium-pipewire-camera.sh
+++ b/camera-relay/chromium-pipewire-camera.sh
@@ -112,11 +112,21 @@ resolve_target_user() {
 # each new browser needed three entries and nobody adds all three.
 #
 # Deliberately absent:
-#   Edge     — ships no enable-webrtc-pipewire-camera flag; nothing to write.
+#   Edge     — does not register the entry in edge://flags, so there is nothing
+#              to write into its Local State. The underlying Chromium feature is
+#              compiled in, so `microsoft-edge --enable-features=WebRtcPipeWireCamera`
+#              does work — just not through this file.
 #   Electron — Slack, Discord, VS Code and friends keep a Local State too, but
 #              they never process about:flags, so an entry there is dead weight
-#              in someone else's config file. They need
-#              --enable-features=WebRTCPipeWireCamera on the command line.
+#              in someone else's config file. The command-line switch does not
+#              help them either: PipeWire *camera* support is not wired into
+#              Electron, only the screen-share capturer. electron#45058 asked
+#              for it and was closed unimplemented.
+#
+# The feature name is `WebRtcPipeWireCamera` — BASE_FEATURE(kWebRtcPipeWireCamera)
+# in media/capture/capture_switches.cc. It is case-sensitive, and
+# --enable-features silently ignores a name it does not recognise, so
+# "WebRTCPipeWireCamera" looks right and does nothing.
 chromium_profile_dirs() {
     local home="$1" root name dir label kind
     local -a names=(
@@ -184,9 +194,16 @@ browser_running() {
         appid=${dir#*/.var/app/}
         appid=${appid%%/*}
         if command -v flatpak >/dev/null 2>&1; then
-            if flatpak ps --columns=application 2>/dev/null | grep -qxF "$appid"; then
-                return 0
-            fi
+            # Buffered, not piped straight into grep -q. Under `set -o pipefail`
+            # a reader that exits on first match SIGPIPEs the writer and the
+            # pipeline reports 141 — the same trap documented above
+            # loopback_real_format in camera-relay. `flatpak ps` output is small
+            # enough that it never fires today, but the failure lands on
+            # "return 1" = not running = write into a live profile, which is the
+            # one direction this whole function exists to prevent.
+            local running
+            running=$(flatpak ps --columns=application 2>/dev/null) || running=""
+            grep -qxF "$appid" <<< "$running" && return 0
             return 1
         fi
         # No flatpak CLI to ask: the lock's PID is meaningless here, so treat a

--- a/camera-relay/tests/test-chromium-pipewire-flag.sh
+++ b/camera-relay/tests/test-chromium-pipewire-flag.sh
@@ -589,6 +589,35 @@ else
     bad "doctor swallowed the remedy for a non-ENABLED profile"
 fi
 
+# ── 10. The feature name we tell people to type ──────────────────────────────
+# Chromium feature names are case-sensitive and --enable-features silently
+# ignores one it does not recognise, so a wrong spelling looks exactly like a
+# right one and simply does nothing. The name is fixed by
+#   BASE_FEATURE(kWebRtcPipeWireCamera, ...)   media/capture/capture_switches.cc
+# and "WebRTCPipeWireCamera" is the plausible-looking wrong version that shipped
+# twice before anyone tried it. Checks every use site, not just this file.
+echo
+echo "documented feature name"
+
+REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+bad_uses=$(grep -rn -- '--enable-features=[A-Za-z]*[Pp]ipe[Ww]ire[Cc]amera' "$REPO" \
+    --exclude-dir=.git 2>/dev/null \
+    | grep -v -- '--enable-features=WebRtcPipeWireCamera' || true)
+if [[ -z "$bad_uses" ]]; then
+    ok "every --enable-features= use site spells it WebRtcPipeWireCamera"
+else
+    bad "misspelled feature name — silently ignored by Chromium:"
+    sed 's/^/      /' <<< "$bad_uses"
+fi
+
+# The flag id in the chrome://flags URL is a separate string from the feature
+# name and is lowercase-with-dashes. Mixing the two up is the other easy error.
+if grep -rq 'chrome://flags/#enable-webrtc-pipewire-camera' "$REPO" --exclude-dir=.git 2>/dev/null; then
+    ok "chrome://flags URL uses the flag id, not the feature name"
+else
+    bad "no chrome://flags/#enable-webrtc-pipewire-camera reference found"
+fi
+
 echo
 echo "  $PASS passed, $FAIL failed"
 [[ $FAIL -eq 0 ]]

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -172,8 +172,10 @@ browsers, not optional** — with one version-specific exception. Check with
   libcamera version instead.
 
 Electron apps (Slack, Teams, Discord, VS Code) use the same Chromium capture
-code and are affected the same way. Launch them with
-`--enable-features=WebRTCPipeWireCamera` if they can't see the camera.
+code and are filtered out the same way, but **the command-line switch does not
+rescue them** — PipeWire *camera* support is not wired into Electron at all. See
+[Chromium can't use the V4L2 relay](#chromium-cant-use-the-v4l2-relay) for the
+detail, and for Edge, which the switch *does* fix.
 
 Quick test:
 


### PR DESCRIPTION
Follow-up to #86.

`--enable-features` **silently ignores a name it does not recognise**, and Chromium feature names are case-sensitive. The name is fixed by `media/capture/capture_switches.cc:49`:

```c
BASE_FEATURE(kWebRtcPipeWireCamera, base::FEATURE_DISABLED_BY_DEFAULT);
```

so it is `WebRtcPipeWireCamera`. Two places said `WebRTCPipeWireCamera`, which looks right and does nothing:

- `webcam-fix-libcamera/README.md` — shipped in #83
- the `Deliberately absent:` comment in `chromium-pipewire-camera.sh` — added in #86

## The README line was worse than a typo

It told Electron users to launch with the switch, while #86 added text further down establishing that **the switch does not help Electron at all** — PipeWire *camera* support is not wired into Electron, only the screen-share capturer ([electron#45058](https://github.com/electron/electron/issues/45058), closed unimplemented). So the file contradicted itself *and* named a feature Chromium ignores. Rewritten to point at the detailed section, which covers both Electron and Edge.

The same comment also still carried the pre-#86 framing of Edge — "ships no `enable-webrtc-pipewire-camera` flag". Edge does not *register the entry* in `edge://flags`, but the underlying feature is compiled in and the command-line switch works. Corrected to match what #86 established everywhere else.

## Also: buffer `flatpak ps`

`flatpak ps --columns=application | grep -qxF "$appid"` is the SIGPIPE-under-pipefail pattern already documented above `loopback_real_format`. The script runs `set -o pipefail`, a reader that exits on first match SIGPIPEs the writer, and the pipeline reports 141:

```
$ bash -c 'set -uo pipefail; seq 1 500000 | grep -qxF 3; echo rc=$?'
rc=141
```

`flatpak ps` output is small enough that the writer always finishes first, so it never fires today. But the failure would land on `return 1` = "not running" = write into a live profile — the one direction that guard exists to prevent.

## Test

New assertion that every `--enable-features=` use site in the repo spells it `WebRtcPipeWireCamera`, because the failure mode here is silence rather than an error. It matches only use sites, so a comment that names the wrong spelling *in order to warn about it* does not trip it — verified against a synthetic fixture with both wrong forms, a correct form and a bare prose mention.

**163 assertions across eight suites, all passing.** `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)