### PR TITLE
webcam-fix-libcamera: warn against the intel-ipu6-dkms offer in Additional Drivers

### DIFF
--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -286,6 +286,76 @@ Some Galaxy Book3/Book4 models have a 26 MHz external clock instead of the expec
 cd ov02c10-26mhz-fix && sudo ./install.sh
 ```
 
+### "Additional Drivers" offers `intel-ipu6-dkms` — don't install it
+
+Ubuntu's **Additional Drivers** panel (`software-properties-gtk`) lists the IPU
+as *"Intel Corporation: Meteor Lake IPU — This device is not working"* and
+offers *"Using Intel Integrated Image Processing Unit 6 (IPU6) driver from
+intel-ipu6-dkms (open source)"*. Leave it on **"Do not use the device"**.
+
+The "not working" label is a false positive. `ubuntu-drivers` matches hardware
+by modalias, and the only modalias `intel-ipu6-dkms` declares is for
+`intel-ipu6-psys` — the PSYS function, which the mainline driver does not
+expose. No installed package claims that modalias, so the panel reports the
+device as unclaimed even while the in-tree driver is bound and streaming:
+
+```bash
+lspci -nnk -d 8086:7d19    # Meteor Lake; use 8086:a75d on Raptor Lake
+```
+
+That prints `Kernel driver in use: intel-ipu6` on a working system.
+
+Installing the offered driver can break the camera. `intel-ipu6-dkms` is the
+out-of-tree Intel stack ([`intel/ipu6-drivers`](https://github.com/intel/ipu6-drivers),
+what the legacy [`webcam-fix/`](../webcam-fix/) is built around), and its
+`dkms.conf` builds **`ov02c10` unconditionally** into `/updates` — the same
+module name and the same directory as the [26 MHz fix](../ov02c10-26mhz-fix/).
+Intel's copy does not carry the 26 MHz patch, so on an affected board the camera
+goes back to `external clock 26000000 is not supported`.
+
+There is nothing to gain in exchange. On any kernel 6.10 or newer, `intel-ipu6`
+and `intel-ipu6-isys` are not built at all (the `dkms.conf` gates them on older
+kernels, because the in-tree drivers took over). What remains is
+`intel-ipu6-psys`, which is only useful to the proprietary camera HAL —
+and `libcamhal0`, `intel-ipu6-camera-hal` and `gstreamer1.0-icamera` have no
+installation candidate on Ubuntu 26.04.
+
+### Camera stopped working after installing `intel-ipu6-dkms`
+
+**Symptom.** The camera worked, you accepted the Additional Drivers offer above,
+and now `camera-relay status` fails or dmesg is back to
+`external clock 26000000 is not supported`.
+
+Check which `ov02c10` the kernel resolves, and who owns it:
+
+```bash
+modinfo -n ov02c10
+dkms status | grep -E 'ov02c10|ipu6'
+```
+
+Remove the Intel stack and reinstate the patched driver:
+
+```bash
+sudo apt purge intel-ipu6-dkms
+sudo dkms install ov02c10/1.0 -k "$(uname -r)"
+sudo depmod -a
+sudo update-initramfs -u
+```
+
+Reboot, then verify. The path must land under `updates/dkms`, not
+`kernel/drivers`, and the clock line must be the patched driver's:
+
+```bash
+modinfo -n ov02c10
+journalctl -k -b -g '26000000Hz clock'
+```
+
+If `modinfo` still points at `kernel/drivers` after the reboot, the DKMS build
+either failed or was rejected. With Secure Boot enabled an unsigned module is
+rejected in silence and the kernel falls back to the in-tree driver — which
+rejects 26 MHz too. See
+[Secure Boot](../ov02c10-26mhz-fix/README.md#secure-boot) in the 26 MHz fix.
+
 ### Too many "ipu6" entries in camera list
 
 Log out and back in for the udev rules and WirePlumber config to take effect, then check with:
@@ -491,6 +561,11 @@ disables and masks `v4l2-relayd.service` and moves the OEM
 `/etc/modprobe.d/v4l2loopback.conf` aside (restored by `uninstall.sh`). Just
 re-run `sudo bash install.sh` and reboot. The change is fully reversible:
 `uninstall.sh` restores the OEM file and re-enables the service.
+
+The kernel-side half of the same OEM stack is `intel-ipu6-dkms`, which Ubuntu's
+Additional Drivers panel offers on these machines — see
+["Additional Drivers" offers `intel-ipu6-dkms`](#additional-drivers-offers-intel-ipu6-dkms--dont-install-it)
+above. Don't install it.
 
 ### LED on but black image, on laptops with a dedicated GPU
 

--- a/webcam-fix-libcamera/README.md
+++ b/webcam-fix-libcamera/README.md
@@ -316,9 +316,13 @@ goes back to `external clock 26000000 is not supported`.
 There is nothing to gain in exchange. On any kernel 6.10 or newer, `intel-ipu6`
 and `intel-ipu6-isys` are not built at all (the `dkms.conf` gates them on older
 kernels, because the in-tree drivers took over). What remains is
-`intel-ipu6-psys`, which is only useful to the proprietary camera HAL —
-and `libcamhal0`, `intel-ipu6-camera-hal` and `gstreamer1.0-icamera` have no
-installation candidate on Ubuntu 26.04.
+`intel-ipu6-psys`, which is only useful to the proprietary camera HAL — the
+[legacy stack](../webcam-fix/) this fix replaces. That HAL is not in the Ubuntu
+archive on any release: `libcamhal-ipu6epmtl` and `gstreamer1.0-icamera` are
+published only in the `ppa:oem-solutions-group/intel-ipu6` OEM PPA, which is not
+enabled on a stock install. So out of the box `intel-ipu6-psys` has nothing to
+feed — and if you *do* enable that PPA, you are setting up the legacy stack
+deliberately, which is a different decision from repairing this one.
 
 ### Camera stopped working after installing `intel-ipu6-dkms`
 
@@ -333,27 +337,36 @@ modinfo -n ov02c10
 dkms status | grep -E 'ov02c10|ipu6'
 ```
 
-Remove the Intel stack and reinstate the patched driver:
+Remove the Intel stack, then re-run the 26 MHz installer to rebuild and
+reinstate the patched driver:
 
 ```bash
 sudo apt purge intel-ipu6-dkms
-sudo dkms install ov02c10/1.0 -k "$(uname -r)"
-sudo depmod -a
-sudo update-initramfs -u
+cd ov02c10-26mhz-fix && sudo ./install.sh
 ```
 
-Reboot, then verify. The path must land under `updates/dkms`, not
-`kernel/drivers`, and the clock line must be the patched driver's:
+Don't reach for `dkms install ov02c10/1.0` directly. Purging the Intel package
+clears *its* DKMS state, not ours — the `ov02c10/1.0` "installed" marker for the
+running kernel survives, and DKMS checks that marker first, so the command exits
+with *"This module/version combo is already installed for kernel …"* and changes
+nothing. [`install.sh`](../ov02c10-26mhz-fix/install.sh) does the full
+`dkms remove --all` → `add` → `build` → `install` cycle, re-signs the module for
+Secure Boot, and refreshes `depmod` and the initramfs (with `dracut` /
+`mkinitcpio` fallbacks off Ubuntu).
+
+Reboot, then verify:
 
 ```bash
-modinfo -n ov02c10
+modinfo -n ov02c10                 # must be under updates/dkms
+modinfo ov02c10 | grep -i '^sig'   # no output = unsigned
 journalctl -k -b -g '26000000Hz clock'
 ```
 
-If `modinfo` still points at `kernel/drivers` after the reboot, the DKMS build
-either failed or was rejected. With Secure Boot enabled an unsigned module is
-rejected in silence and the kernel falls back to the in-tree driver — which
-rejects 26 MHz too. See
+A path under `kernel/drivers` means the DKMS build or install failed. The right
+path with no `sig*` fields means the module was built but is unsigned, so under
+Secure Boot it is rejected at load time and the in-tree driver wins — which
+rejects 26 MHz too. `modinfo -n` reads the path out of `modules.dep` and cannot
+see that rejection, which is why the signature needs its own check. See
 [Secure Boot](../ov02c10-26mhz-fix/README.md#secure-boot) in the 26 MHz fix.
 
 ### Too many "ipu6" entries in camera list


### PR DESCRIPTION
## What

Two new troubleshooting sections in `webcam-fix-libcamera/README.md`, plus a cross-link from the existing `v4l2-relayd` section.

- **`### "Additional Drivers" offers intel-ipu6-dkms — don't install it`** — preventive note: why the panel is wrong, and what installing it costs.
- **`### Camera stopped working after installing intel-ipu6-dkms`** — recovery runbook for anyone who already accepted the offer.

Docs only. No code, no installer changes.

## Why

Ubuntu's Additional Drivers panel (`software-properties-gtk`) lists the IPU as **"This device is not working"** and offers `intel-ipu6-dkms` — on a machine where the camera is already streaming fine through the in-tree driver:

> Intel Corporation: Meteor Lake IPU
> This device is not working.
> ( ) Using Intel Integrated Image Processing Unit 6 (IPU6) driver from intel-ipu6-dkms (open source)
> (•) Do not use the device

The label is a **false positive**. `ubuntu-drivers` matches by modalias, and the only modalias `intel-ipu6-dkms` declares is for `intel-ipu6-psys` — the PSYS function, which the mainline driver does not expose. Nothing claims it, so the device reads as unclaimed even while `intel-ipu6` is bound and `Connected 1 cameras`.

Accepting the offer can **break the camera**. `intel-ipu6-dkms` is the out-of-tree [`intel/ipu6-drivers`](https://github.com/intel/ipu6-drivers) stack, and its `dkms.conf` builds **`ov02c10` unconditionally** into `/updates` — the same module name and the same directory as our `ov02c10-26mhz-fix`. Intel's copy has no 26 MHz patch, so an affected board goes straight back to `external clock 26000000 is not supported`.

And there is nothing to gain in exchange:

| Module | Built on kernel ≥ 6.10? | Useful here? |
|---|---|---|
| `ov02c10` | yes, unconditional | **no** — overwrites our patched copy |
| `intel-ipu6`, `intel-ipu6-isys` | no (gated on < 6.10) | in-tree drivers already own this |
| `intel-ipu6-psys` | yes, unconditional | only serves the proprietary HAL |
| `cio2-bridge` | not in `dkms.conf` | — (`ipu-bridge-fix` is unaffected) |

`libcamhal0`, `intel-ipu6-camera-hal` and `gstreamer1.0-icamera` have **no installation candidate** on Ubuntu 26.04, so the PSYS module has nothing to feed.

The repo had zero mentions of `intel-ipu6-dkms`, `ubuntu-drivers` or "Additional Drivers" anywhere in the tree — so every Ubuntu user meets this offer with no warning, and the obvious move is to accept it.

## Reviewer notes

- **Placement** is next to the 26 MHz entry rather than next to the `v4l2-relayd` one, because the collision is specifically on `ov02c10`. A reader who lands on the clock error needs to know the Intel DKMS may be the cause. The `v4l2-relayd` section gets a one-paragraph pointer instead — `intel-ipu6-dkms` is the kernel-side half of the same OEM stack.
- **Secure Boot** is called out in the runbook: an unsigned DKMS module is rejected silently and the kernel falls back to the in-tree driver, which rejects 26 MHz too. Links to the existing `ov02c10-26mhz-fix/README.md#secure-boot` rather than restating it.
- **The `lspci` line uses device IDs** (`-d 8086:7d19`, with `8086:a75d` in a comment) instead of grepping the description — lspci classifies the IPU as *Multimedia controller*, not *Image Processing*, so the obvious grep finds nothing.

## Verification

Every command in the new sections was run on an affected board — Galaxy Book4 Ultra `NP960XGL-XG1BR` (`960XGL`), Meteor Lake IPU6 `8086:7d19`, Ubuntu 26.04, kernel `7.0.0-29-generic`, **Secure Boot enabled**:

```
$ lspci -nnk -d 8086:7d19
00:05.0 Multimedia controller [0480]: Intel Corporation Meteor Lake IPU [8086:7d19] (rev 04)
        Kernel driver in use: intel-ipu6

$ modinfo -n ov02c10
/lib/modules/7.0.0-29-generic/updates/dkms/ov02c10.ko.zst

$ journalctl -k -b -g '26000000Hz clock'
ov02c10 i2c-OVTI02C1:00: 26000000Hz clock (not 19200000Hz): sensor runs fast; ... ~30fps
```

Claims about the package were checked against the archive, not from memory: `apt-cache show intel-ipu6-dkms` for the modalias, the `.deb` file listing on packages.ubuntu.com for the shipped sources, and the upstream `dkms.conf` for the build conditionals and `DEST_MODULE_LOCATION`.

Markdown checked: heading order, balanced fences, and the in-page anchor slug (the heading carries quotes, backticks, an em dash and an apostrophe, so the anchor needs the double hyphen).

The recovery commands are documented, not executed — nothing on the test machine was changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
