### PR TITLE
fix: webcam-fix-libcamera detects Fedora as Arch when pacman is installed

### DIFF
--- a/camera-relay/tests/test-distro-detection.sh
+++ b/camera-relay/tests/test-distro-detection.sh
@@ -1,0 +1,176 @@
+#!/usr/bin/env bash
+# Regression tests for distro detection in webcam-fix-libcamera/install.sh.
+#
+# The script used to identify the distro purely by which package manager
+# binary existed, checking `pacman` first. That heuristic is wrong on any
+# distro that ships another distro's package manager — and Fedora does: it
+# packages a real `pacman` (e.g. pacman-7.0.0-5.fc43 on Fedora 43). A Fedora
+# host with it installed was greeted with "✓ Arch-based detected" and the
+# install died at step [9/14] trying Arch package names:
+#
+#   error: target not found: git
+#   error: target not found: meson
+#
+# Detection now reads /etc/os-release (ID, then the ID_LIKE ancestry list)
+# and probes for package managers only when os-release gives no answer.
+# These tests drive the extracted detect_distro() against fixture os-release
+# files and a stub-only PATH, so they need no root and touch no system state.
+#
+# Usage: ./test-distro-detection.sh
+
+set -uo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+INSTALL="$ROOT/webcam-fix-libcamera/install.sh"
+PASS=0
+FAIL=0
+
+ok()  { echo "  ✓ $*"; PASS=$((PASS + 1)); }
+bad() { echo "  ✗ $*"; FAIL=$((FAIL + 1)); }
+
+TMP=$(mktemp -d)
+trap 'rm -rf "$TMP"' EXIT
+
+echo "test-distro-detection ($INSTALL)"
+
+# The function is pure bash (only builtins), so the subshell can run with
+# PATH containing nothing but the stub package managers — `command -v` then
+# sees exactly the set each scenario declares, never the host's binaries.
+FN_SRC=$(sed -n '/^detect_distro()/,/^}/p' "$INSTALL")
+if [[ -z "$FN_SRC" ]]; then
+    bad "detect_distro() not found in install.sh — tests cannot run"
+    echo; echo "$PASS passed, $FAIL failed"
+    exit 1
+fi
+
+# run_detect <os-release file or -> [pm...] → "DISTRO|DISTRO_LABEL" on stdout.
+# "-" means no os-release (a path that does not exist). Exits 9 on rejection.
+run_detect() {
+    local os_release="$1"; shift
+    [[ "$os_release" == "-" ]] && os_release="$TMP/does-not-exist"
+    local bindir="$TMP/bin-$RANDOM$RANDOM" pm
+    mkdir -p "$bindir"
+    for pm in "$@"; do
+        printf '#!/bin/sh\nexit 0\n' > "$bindir/$pm"
+        chmod +x "$bindir/$pm"
+    done
+    (
+        set -e
+        PATH="$bindir"
+        DISTRO=""; DISTRO_LABEL=""
+        eval "$FN_SRC"
+        detect_distro "$os_release" >/dev/null 2>&1 || exit 9
+        echo "$DISTRO|$DISTRO_LABEL"
+    )
+}
+
+check() {
+    local desc="$1" want="$2" got
+    got=$(run_detect "${@:3}")
+    if [[ "$got" == "$want"* ]]; then
+        ok "$desc → ${got%%|*}"
+    else
+        bad "$desc: want '$want*', got '${got:-<rejected>}'"
+    fi
+}
+
+fixture() {
+    local name="$1"; shift
+    printf '%s\n' "$@" > "$TMP/$name"
+    echo "$TMP/$name"
+}
+
+# ── 1. The bug itself ────────────────────────────────────────────────────────
+echo
+echo "Fedora with pacman installed stays Fedora"
+
+FEDORA=$(fixture fedora 'NAME="Fedora Linux"' 'ID=fedora' \
+    'PRETTY_NAME="Fedora Linux 43 (Workstation Edition)"')
+check "Fedora 43 with both dnf and pacman" "fedora|Fedora/DNF-based" \
+    "$FEDORA" dnf pacman
+
+# ── 2. Every supported distro still detects ──────────────────────────────────
+echo
+echo "supported distros and derivatives"
+
+ARCH=$(fixture arch 'ID=arch' 'PRETTY_NAME="Arch Linux"')
+check "Arch" "arch|Arch-based" "$ARCH" pacman
+
+ENDEAVOUR=$(fixture endeavouros 'ID=endeavouros' 'ID_LIKE=arch' \
+    'PRETTY_NAME="EndeavourOS"')
+check "EndeavourOS (ID_LIKE=arch)" "arch|Arch-based" "$ENDEAVOUR" pacman
+
+NOBARA=$(fixture nobara 'ID=nobara' 'ID_LIKE="fedora"' \
+    'PRETTY_NAME="Nobara Linux 42"')
+check "Nobara (ID_LIKE=fedora)" "fedora|Fedora/DNF-based" "$NOBARA" dnf
+
+UBUNTU=$(fixture ubuntu 'ID=ubuntu' 'ID_LIKE=debian' \
+    'PRETTY_NAME="Ubuntu 24.04.2 LTS"')
+check "Ubuntu" "ubuntu|Ubuntu/Ubuntu-based" "$UBUNTU" apt
+
+POP=$(fixture pop 'ID=pop' 'ID_LIKE="ubuntu debian"' \
+    'PRETTY_NAME="Pop!_OS 22.04 LTS"')
+check "Pop!_OS" "ubuntu|Ubuntu/Ubuntu-based" "$POP" apt
+
+MINT=$(fixture mint 'ID=linuxmint' 'ID_LIKE="ubuntu debian"' \
+    'PRETTY_NAME="Linux Mint 22"')
+check "Linux Mint" "ubuntu|Ubuntu/Ubuntu-based" "$MINT" apt
+
+# An Ubuntu descendant known only through ID_LIKE keeps the descriptive label.
+ZORIN=$(fixture zorin 'ID=zorin' 'ID_LIKE="ubuntu debian"' \
+    'PRETTY_NAME="Zorin OS 17"')
+check "Zorin (ID_LIKE ubuntu before debian)" "ubuntu|Ubuntu-based (Zorin OS 17)" \
+    "$ZORIN" apt
+
+DEBIAN=$(fixture debian 'ID=debian' 'PRETTY_NAME="Debian GNU/Linux 13"')
+check "Debian" "debian|Debian-based" "$DEBIAN" apt
+
+# ── 3. Fallback when os-release is missing ───────────────────────────────────
+echo
+echo "package-manager fallback without os-release"
+
+check "pacman only" "arch|Arch-based" - pacman
+check "dnf only" "fedora|Fedora/DNF-based" - dnf
+check "apt only" "debian|Debian-based" - apt
+
+# ── 4. Unsupported systems are rejected ──────────────────────────────────────
+echo
+echo "unsupported"
+
+GENTOO=$(fixture gentoo 'ID=gentoo' 'PRETTY_NAME="Gentoo Linux"')
+if run_detect "$GENTOO" >/dev/null 2>&1; then
+    bad "Gentoo without a supported package manager was accepted"
+else
+    ok "Gentoo without a supported package manager is rejected"
+fi
+if run_detect - >/dev/null 2>&1; then
+    bad "no os-release and no package manager was accepted"
+else
+    ok "no os-release and no package manager is rejected"
+fi
+
+# ── 5. install.sh actually uses the function ─────────────────────────────────
+# Guards against the block being reverted to a bare package-manager probe
+# while the (then-orphaned) function keeps these tests green.
+echo
+echo "wiring"
+
+if grep -qE '^detect_distro$' "$INSTALL"; then
+    ok "install.sh calls detect_distro at top level"
+else
+    bad "install.sh does not call detect_distro"
+fi
+probes=$(grep -c 'command -v pacman' "$INSTALL" || true)
+fn_start=$(grep -n '^detect_distro()' "$INSTALL" | cut -d: -f1)
+fn_end=$(awk "NR>$fn_start && /^}/{print NR; exit}" "$INSTALL")
+outside=$(grep -n 'command -v pacman' "$INSTALL" \
+    | awk -F: -v s="$fn_start" -v e="$fn_end" '$1 < s || $1 > e' | wc -l)
+if [[ "$outside" == "0" && "$probes" != "0" ]]; then
+    ok "every pacman probe lives inside detect_distro's fallback"
+else
+    bad "$outside pacman probe(s) outside detect_distro — os-release no longer wins"
+fi
+
+echo
+echo "$PASS passed, $FAIL failed"
+[[ $FAIL -eq 0 ]]

--- a/webcam-fix-libcamera/install.sh
+++ b/webcam-fix-libcamera/install.sh
@@ -94,28 +94,70 @@ fi
 # ──────────────────────────────────────────────
 # [2/14] Distro detection
 # ──────────────────────────────────────────────
-echo "[2/14] Detecting distro..."
-if command -v pacman >/dev/null 2>&1; then
-    DISTRO="arch"
-    DISTRO_LABEL="Arch-based"
-elif command -v dnf >/dev/null 2>&1; then
-    DISTRO="fedora"
-    DISTRO_LABEL="Fedora/DNF-based"
-elif command -v apt >/dev/null 2>&1; then
-    if [[ -f /etc/os-release ]] && grep -qiE '^ID=(ubuntu|pop|linuxmint)' /etc/os-release; then
-        DISTRO="ubuntu"
-        DISTRO_LABEL="Ubuntu/Ubuntu-based"
-    elif [[ -f /etc/os-release ]] && grep -qiE '^ID_LIKE=.*ubuntu' /etc/os-release; then
-        DISTRO="ubuntu"
-        DISTRO_LABEL="Ubuntu-based ($(grep '^PRETTY_NAME=' /etc/os-release | cut -d= -f2 | tr -d '"'))"
-    else
-        DISTRO="debian"
-        DISTRO_LABEL="Debian-based"
+# Identify the distro from os-release (ID first, then ID_LIKE) and only fall
+# back to probing for a package manager when os-release gives no answer. The
+# binary probe alone is not trustworthy: Fedora ships a real `pacman` package,
+# so a Fedora host with it installed used to be detected as Arch and step
+# [9/14] then tried to install Arch package names with pacman.
+# Takes an optional os-release path (default /etc/os-release) so tests can
+# feed it fixture files. Sets DISTRO and DISTRO_LABEL.
+detect_distro() {
+    local os_release="${1:-/etc/os-release}"
+    local id="" id_like="" pretty_name="" key value
+
+    if [[ -r "$os_release" ]]; then
+        while IFS='=' read -r key value; do
+            value="${value%\"}"; value="${value#\"}"
+            value="${value%\'}"; value="${value#\'}"
+            case "$key" in
+                ID)          id="${value,,}" ;;
+                ID_LIKE)     id_like="${value,,}" ;;
+                PRETTY_NAME) pretty_name="$value" ;;
+            esac
+        done < "$os_release"
     fi
-else
-    echo "ERROR: Unsupported distro. This script requires pacman (Arch), dnf (Fedora), or apt (Ubuntu)."
-    exit 1
-fi
+
+    case "$id" in
+        arch)                 DISTRO="arch";   DISTRO_LABEL="Arch-based" ;;
+        fedora)               DISTRO="fedora"; DISTRO_LABEL="Fedora/DNF-based" ;;
+        ubuntu|pop|linuxmint) DISTRO="ubuntu"; DISTRO_LABEL="Ubuntu/Ubuntu-based" ;;
+        debian)               DISTRO="debian"; DISTRO_LABEL="Debian-based" ;;
+    esac
+
+    # ID_LIKE is a space-separated ancestry list, e.g. EndeavourOS has
+    # ID=endeavouros ID_LIKE=arch and Pop!_OS has ID_LIKE="ubuntu debian".
+    # Ubuntu is checked before Debian so Ubuntu descendants keep apt PPAs.
+    if [[ -z "$DISTRO" ]]; then
+        case " $id_like " in
+            *" arch "*)   DISTRO="arch";   DISTRO_LABEL="Arch-based (${pretty_name:-$id})" ;;
+            *" fedora "*) DISTRO="fedora"; DISTRO_LABEL="Fedora/DNF-based (${pretty_name:-$id})" ;;
+            *" ubuntu "*) DISTRO="ubuntu"; DISTRO_LABEL="Ubuntu-based (${pretty_name:-$id})" ;;
+            *" debian "*) DISTRO="debian"; DISTRO_LABEL="Debian-based (${pretty_name:-$id})" ;;
+        esac
+    fi
+
+    # Last resort for systems without a usable os-release: probe package
+    # managers and accept the ambiguity that has on hybrid systems.
+    if [[ -z "$DISTRO" ]]; then
+        if command -v pacman >/dev/null 2>&1; then
+            DISTRO="arch";   DISTRO_LABEL="Arch-based"
+        elif command -v dnf >/dev/null 2>&1; then
+            DISTRO="fedora"; DISTRO_LABEL="Fedora/DNF-based"
+        elif command -v apt >/dev/null 2>&1; then
+            DISTRO="debian"; DISTRO_LABEL="Debian-based"
+        fi
+    fi
+
+    if [[ -z "$DISTRO" ]]; then
+        echo "ERROR: Unsupported distro. This script supports Arch, Fedora, and Ubuntu/Debian (and derivatives)."
+        exit 1
+    fi
+}
+
+echo "[2/14] Detecting distro..."
+DISTRO=""
+DISTRO_LABEL=""
+detect_distro
 echo "  ✓ $DISTRO_LABEL detected"
 
 # ──────────────────────────────────────────────


### PR DESCRIPTION
## The failure

On Fedora 43, `webcam-fix-libcamera/install.sh` printed:

```
✓ Arch-based detected
```

and later died at `[9/14] Installing libcamera...` trying to install Arch package names with pacman:

```
error: target not found: git
error: target not found: meson
error: target not found: ninja
error: target not found: gcc
```

Root cause: the script identifies the distro by whichever package-manager binary exists, checking `pacman` **before** `dnf`. But a package manager binary does not uniquely identify the OS — Fedora ships a real `pacman` package (`pacman-7.0.0-5.fc43.x86_64` here, installable from the standard repos), so any Fedora host that has it is misdetected as Arch.

## The fix

Detection now reads `/etc/os-release` first — `ID`, then the `ID_LIKE` ancestry list — and only falls back to probing for package managers when os-release gives no answer (the pre-existing behavior, kept as a last resort for unusual systems). The logic moves into a `detect_distro()` function so it can be tested in isolation.

Mapping is unchanged for everything that worked before:

- `ID=arch` or `ID_LIKE` containing `arch` (EndeavourOS, Manjaro, …) → `arch`
- `ID=fedora` or `ID_LIKE` containing `fedora` (Nobara, RHEL family) → `fedora`
- `ID=ubuntu|pop|linuxmint` or `ID_LIKE` containing `ubuntu` (checked before `debian`, as before) → `ubuntu`
- `ID=debian` / `ID_LIKE` containing `debian` → `debian`
- nothing recognizable → same "Unsupported distro" error

## Tests

Added `camera-relay/tests/test-distro-detection.sh` (same conventions as the existing suites there): extracts `detect_distro()` from the script and runs it against fixture os-release files with a stub-only `PATH`, so the host system never leaks in. 16 checks: the Fedora-with-pacman regression, all supported distros and derivatives, the no-os-release fallback, rejection of unsupported systems, plus wiring checks that guard against the block reverting to a bare binary probe.

```
$ camera-relay/tests/test-distro-detection.sh
...
16 passed, 0 failed
$ camera-relay/tests/test-pipewire-restart-guard.sh   # existing suite, still green
17 passed, 0 failed
```

Also verified live on the affected Fedora 43 machine (with `/usr/bin/pacman` present): detection now reports `Fedora/DNF-based`.

## Test plan

- [x] `bash -n webcam-fix-libcamera/install.sh`
- [x] New test suite: 16/16 pass
- [x] Existing `test-pipewire-restart-guard.sh`: 17/17 pass
- [x] Live run of the detection step on Fedora 43 with pacman installed

## Note on sibling scripts

`webcam-fix/install.sh`, `webcam-fix-book5/install.sh` and `webcam-fix/uninstall.sh` share the same pacman-first probe and are misdetected the same way; `mic-fix`, `speaker-fix` and `speaker-fix-940xfg` happen to check `dnf` first and are unaffected. Left out of this PR to keep it reviewable — happy to follow up with the same treatment if you want it.